### PR TITLE
refactor: minify reth dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "main" 
 reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "main" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "main" }
 reth-db-common = { git = "https://github.com/paradigmxyz/reth", branch = "main" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "main" }
 reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "main" }
 reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "main" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "main" }
@@ -68,6 +67,9 @@ alloy-trie = { version = "0.9", default-features = false }
 
 # revm
 revm = { version = "34.0.0", default-features = false }
+revm-bytecode = { version = "8.0.0", default-features = false }
+revm-database-interface = { version = "9.0.0", default-features = false }
+revm-state = { version = "9.0.0", default-features = false }
 
 # misc
 itertools = "0.14"

--- a/crates/stateless/Cargo.toml
+++ b/crates/stateless/Cargo.toml
@@ -24,13 +24,16 @@ alloy-genesis = { workspace = true, features = ["serde-bincode-compat"] }
 reth-ethereum-consensus.workspace = true
 reth-primitives-traits.workspace = true
 reth-ethereum-primitives = { workspace = true, features = ["serde", "serde-bincode-compat"] }
-reth-errors.workspace = true
 reth-evm.workspace = true
-reth-revm.workspace = true
 reth-trie-common.workspace = true
 reth-trie-sparse.workspace = true
 reth-chainspec.workspace = true
 reth-consensus.workspace = true
+
+# revm
+revm-bytecode.workspace = true
+revm-database-interface.workspace = true
+revm-state.workspace = true
 
 # misc
 thiserror.workspace = true

--- a/crates/stateless/src/error.rs
+++ b/crates/stateless/src/error.rs
@@ -1,0 +1,33 @@
+use alloc::string::String;
+use core::fmt;
+
+/// Error type for witness database operations.
+#[derive(Debug)]
+pub enum WitnessDbError {
+    /// Incomplete or missing witness data.
+    TrieWitness(String),
+    /// Missing state for a block number.
+    StateNotFound(u64),
+    /// RLP decoding error.
+    Rlp(alloy_rlp::Error),
+}
+
+impl fmt::Display for WitnessDbError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TrieWitness(msg) => write!(f, "trie witness error: {msg}"),
+            Self::StateNotFound(num) => write!(f, "state for block {num} not found"),
+            Self::Rlp(err) => write!(f, "RLP decode error: {err}"),
+        }
+    }
+}
+
+impl core::error::Error for WitnessDbError {}
+
+impl revm_database_interface::DBErrorMarker for WitnessDbError {}
+
+impl From<alloy_rlp::Error> for WitnessDbError {
+    fn from(err: alloy_rlp::Error) -> Self {
+        Self::Rlp(err)
+    }
+}

--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! # Key Components
 //!
-//! * `WitnessDatabase`: An implementation of [`reth_revm::Database`] that uses a
+//! * `WitnessDatabase`: An implementation of [`revm_database_interface::Database`] that uses a
 //!   [`reth_trie_sparse::SparseStateTrie`] populated from witness data, along with provided
 //!   bytecode and ancestor block hashes, to serve state reads during execution.
 //! * `stateless_validation`: The core function that orchestrates the stateless validation process.
@@ -35,6 +35,8 @@
 
 extern crate alloc;
 
+/// Error types for witness database operations.
+pub mod error;
 mod recover_block;
 /// Sparse trie implementation for stateless validation
 pub mod trie;

--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -1,3 +1,4 @@
+use crate::error::WitnessDbError;
 use crate::validation::StatelessValidationError;
 use alloc::{format, vec::Vec};
 use alloy_primitives::{Address, B256, U256, keccak256, map::B256Map};
@@ -5,14 +6,13 @@ use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_trie::{EMPTY_ROOT_HASH, TrieAccount};
 use itertools::Itertools;
-use reth_errors::ProviderError;
-use reth_revm::state::Bytecode;
 use reth_trie_common::{HashedPostState, Nibbles, TRIE_ACCOUNT_RLP_MAX_SIZE};
 use reth_trie_sparse::{
     RevealableSparseTrie, SparseStateTrie, SparseTrie,
     errors::SparseStateTrieResult,
     provider::{DefaultTrieNodeProvider, DefaultTrieNodeProviderFactory},
 };
+use revm_bytecode::Bytecode;
 
 /// Trait for stateless trie implementations that can be used for stateless validation.
 pub trait StatelessTrie: core::fmt::Debug {
@@ -28,13 +28,13 @@ pub trait StatelessTrie: core::fmt::Debug {
     ///
     /// This method will error if the `ExecutionWitness` is not able to guarantee
     /// that the account is missing from the Trie _and_ the witness was complete.
-    fn account(&self, address: Address) -> Result<Option<TrieAccount>, ProviderError>;
+    fn account(&self, address: Address) -> Result<Option<TrieAccount>, WitnessDbError>;
 
     /// Returns the storage slot value that corresponds to the given (address, slot) tuple.
     ///
     /// This method will error if the `ExecutionWitness` is not able to guarantee
     /// that the storage was missing from the Trie _and_ the witness was complete.
-    fn storage(&self, address: Address, slot: U256) -> Result<U256, ProviderError>;
+    fn storage(&self, address: Address, slot: U256) -> Result<U256, WitnessDbError>;
 
     /// Computes the new state root from the `HashedPostState`.
     fn calculate_state_root(
@@ -66,7 +66,7 @@ impl StatelessSparseTrie {
     ///
     /// This method will error if the `ExecutionWitness` is not able to guarantee
     /// that the account is missing from the Trie _and_ the witness was complete.
-    pub fn account(&self, address: Address) -> Result<Option<TrieAccount>, ProviderError> {
+    pub fn account(&self, address: Address) -> Result<Option<TrieAccount>, WitnessDbError> {
         let hashed_address = keccak256(address);
 
         if let Some(bytes) = self.inner.get_account_value(&hashed_address) {
@@ -75,7 +75,7 @@ impl StatelessSparseTrie {
         }
 
         if !self.inner.check_valid_account_witness(hashed_address) {
-            return Err(ProviderError::TrieWitnessError(format!(
+            return Err(WitnessDbError::TrieWitness(format!(
                 "incomplete account witness for {hashed_address:?}"
             )));
         }
@@ -87,7 +87,7 @@ impl StatelessSparseTrie {
     ///
     /// This method will error if the `ExecutionWitness` is not able to guarantee
     /// that the storage was missing from the Trie _and_ the witness was complete.
-    pub fn storage(&self, address: Address, slot: U256) -> Result<U256, ProviderError> {
+    pub fn storage(&self, address: Address, slot: U256) -> Result<U256, WitnessDbError> {
         let hashed_address = keccak256(address);
         let hashed_slot = keccak256(B256::from(slot));
 
@@ -104,14 +104,14 @@ impl StatelessSparseTrie {
             if account.storage_root != EMPTY_ROOT_HASH
                 && !self.inner.check_valid_storage_witness(hashed_address, hashed_slot)
             {
-                return Err(ProviderError::TrieWitnessError(format!(
+                return Err(WitnessDbError::TrieWitness(format!(
                     "incomplete storage witness: prover must supply exclusion proof for slot {hashed_slot:?} in account {hashed_address:?}"
                 )));
             }
         } else if !self.inner.check_valid_account_witness(hashed_address) {
             // ...else if account is missing, validate that the account trie was sufficiently
             // revealed.
-            return Err(ProviderError::TrieWitnessError(format!(
+            return Err(WitnessDbError::TrieWitness(format!(
                 "incomplete account witness for {hashed_address:?}"
             )));
         }
@@ -137,11 +137,11 @@ impl StatelessTrie for StatelessSparseTrie {
         Self::new(witness, pre_state_root)
     }
 
-    fn account(&self, address: Address) -> Result<Option<TrieAccount>, ProviderError> {
+    fn account(&self, address: Address) -> Result<Option<TrieAccount>, WitnessDbError> {
         self.account(address)
     }
 
-    fn storage(&self, address: Address, slot: U256) -> Result<U256, ProviderError> {
+    fn storage(&self, address: Address, slot: U256) -> Result<U256, WitnessDbError> {
         self.storage(address, slot)
     }
 

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -14,8 +14,8 @@ use alloc::{
 use alloy_consensus::{BlockHeader, Header};
 use alloy_primitives::{B256, keccak256};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_consensus::ConsensusError;
 use reth_consensus::{Consensus, HeaderValidator};
-use reth_errors::ConsensusError;
 use reth_ethereum_consensus::{EthBeaconConsensus, validate_block_post_execution};
 use reth_ethereum_primitives::{Block, EthPrimitives, EthereumReceipt};
 use reth_evm::{

--- a/crates/stateless/src/witness_db.rs
+++ b/crates/stateless/src/witness_db.rs
@@ -1,15 +1,17 @@
-//! Provides the [`WitnessDatabase`] type, an implementation of [`reth_revm::Database`]
+//! Provides the [`WitnessDatabase`] type, an implementation of [`revm_database_interface::Database`]
 //! specifically designed for stateless execution environments.
 
+use crate::error::WitnessDbError;
 use crate::trie::StatelessTrie;
 use alloc::{collections::btree_map::BTreeMap, format};
 use alloy_primitives::{Address, B256, U256, map::B256Map};
-use reth_errors::ProviderError;
-use reth_revm::{Database, bytecode::Bytecode, state::AccountInfo};
+use revm_bytecode::Bytecode;
+use revm_database_interface::Database;
+use revm_state::AccountInfo;
 
 /// An EVM database implementation backed by witness data.
 ///
-/// This struct implements the [`reth_revm::Database`] trait, allowing the EVM to execute
+/// This struct implements the [`revm_database_interface::Database`] trait, allowing the EVM to execute
 /// transactions using:
 ///  - Account and storage slot data provided by a [`StatelessTrie`] implementation.
 ///  - Bytecode and ancestor block hashes provided by in-memory maps.
@@ -63,7 +65,7 @@ where
     T: StatelessTrie,
 {
     /// The database error type.
-    type Error = ProviderError;
+    type Error = WitnessDbError;
 
     /// Get basic account information by hashing the address and looking up the account RLP
     /// in the underlying [`StatelessTrie`] implementation.
@@ -93,7 +95,7 @@ where
     /// Returns an error if the bytecode for the given hash is not found in the map.
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         self.bytecode.get(&code_hash).cloned().ok_or_else(|| {
-            ProviderError::TrieWitnessError(format!("bytecode for {code_hash} not found"))
+            WitnessDbError::TrieWitness(format!("bytecode for {code_hash} not found"))
         })
     }
 
@@ -104,6 +106,6 @@ where
         self.block_hashes_by_block_number
             .get(&block_number)
             .copied()
-            .ok_or(ProviderError::StateForNumberNotFound(block_number))
+            .ok_or(WitnessDbError::StateNotFound(block_number))
     }
 }


### PR DESCRIPTION
## Summary
Reduce reth dependency surface in the core stateless crate.

## Changes
- Drop `reth-revm` → use `revm-database-interface`, `revm-bytecode`, `revm-state` directly
- Drop `reth-errors` → import `ConsensusError` from `reth-consensus`, replace `ProviderError` with local `WitnessDbError`

### Before (10 reth deps)
`reth-chainspec`, `reth-consensus`, `reth-errors`, `reth-ethereum-consensus`, `reth-ethereum-primitives`, `reth-evm`, `reth-primitives-traits`, `reth-revm`, `reth-trie-common`, `reth-trie-sparse`

### After (8 reth deps)
`reth-chainspec`, `reth-consensus`, `reth-ethereum-consensus`, `reth-ethereum-primitives`, `reth-evm`, `reth-primitives-traits`, `reth-trie-common`, `reth-trie-sparse`

The remaining 8 are structurally required — they provide consensus rules, EVM execution, trie operations, and Ethereum primitive types that can't be trivially replaced without a larger rewrite.

## Testing
`cargo check --workspace` passes with zero warnings

Slack thread: https://tempoxyz.slack.com/archives/C09FQDW2ZRP/p1770760391049139