### PR TITLE
ef-tests: use production db setup to support heavy benchmark cases

### DIFF
--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -19,7 +19,7 @@ use reth_primitives_traits::{
 use reth_provider::{
     BlockWriter, DatabaseProviderFactory, ExecutionOutcome, HistoryWriter, OriginalValuesKnown,
     StateWriteConfig, StateWriter, StaticFileProviderFactory, StaticFileSegment, StaticFileWriter,
-    test_utils::create_test_provider_factory_with_chain_spec,
+    test_utils::create_test_provider_factory_with_chain_spec_and_db_args,
 };
 use reth_revm::{State, database::StateProviderDatabase, witness::ExecutionWitnessRecord};
 use reth_trie::{HashedPostState, KeccakKeyHasher, StateRoot};
@@ -252,7 +252,10 @@ where
 {
     // Create a new test database and initialize a provider for the test case.
     let chain_spec = case.network.to_chain_spec();
-    let factory = create_test_provider_factory_with_chain_spec(chain_spec.clone());
+    let factory = create_test_provider_factory_with_chain_spec_and_db_args(
+        chain_spec.clone(),
+        reth_db::mdbx::DatabaseArguments::test().with_geometry_max_size(Some(1024 * 1024 * 1024)),
+    );
     let provider = factory.database_provider_rw().unwrap();
 
     // Insert initial test state into the provider.


### PR DESCRIPTION
The current `ef-tests` crate is used to run EEST tests and generate the `ExecutionWitness`. 

In a recent PR in Reth, [the database configuration for tests caps the size to 64MiB](https://github.com/paradigmxyz/reth/pull/21764/changes#diff-047121c09675075f1097b8f707a9a67b02fd89665dd3e962a861488f78a031c7R157). While this makes sense for regular tests, in benchmark cases we are creating worst cases that can exceed this limit.

Concretely, I was re-filling EEST tests for even lowerish 25M gas limits and in worst-cases of bytecodes needed for non-code-chunking attacks, the witness generation failed since we need to create more than 100MiB of bytecodes which exceeds the now default 64MiB db size limit.

This PR makes a local fix for this particular need in this repo, but I think medium/long term might be better that we make this configurable in the Reth repo via params, and then simplify here.