### PR TITLE
feat(ef-tests): add `PragueToOsaka` and BPO transition fork specs

### DIFF
--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -323,6 +323,14 @@ pub enum ForkSpec {
     Prague,
     /// Osaka
     Osaka,
+    /// Prague to Osaka at time 15k
+    PragueToOsakaAtTime15k,
+    /// Osaka to BPO1 at time 15k
+    #[serde(alias = "OsakaToBPO1AtTime15k")]
+    OsakaToBpo1AtTime15k,
+    /// BPO1 to BPO2 at time 15k
+    #[serde(alias = "BPO1ToBPO2AtTime15k")]
+    Bpo1ToBpo2AtTime15k,
 }
 
 impl ForkSpec {
@@ -391,6 +399,16 @@ impl ForkSpec {
                 .with_fork(EthereumHardfork::Prague, ForkCondition::Timestamp(15_000)),
             Self::Prague => spec_builder.prague_activated(),
             Self::Osaka => spec_builder.osaka_activated(),
+            Self::PragueToOsakaAtTime15k => spec_builder
+                .prague_activated()
+                .with_fork(EthereumHardfork::Osaka, ForkCondition::Timestamp(15_000)),
+            Self::OsakaToBpo1AtTime15k => spec_builder
+                .osaka_activated()
+                .with_fork(EthereumHardfork::Bpo1, ForkCondition::Timestamp(15_000)),
+            Self::Bpo1ToBpo2AtTime15k => spec_builder
+                .osaka_activated()
+                .with_fork(EthereumHardfork::Bpo1, ForkCondition::Timestamp(0))
+                .with_fork(EthereumHardfork::Bpo2, ForkCondition::Timestamp(15_000)),
         }
         .build()
     }


### PR DESCRIPTION
## Summary
- Adds `PragueToOsakaAtTime15k`, `OsakaToBpo1AtTime15k`, and `Bpo1ToBpo2AtTime15k` to `ForkSpec`
- These transition forks are used by BAL/zkEVM test fixtures from `ethereum/execution-spec-tests`