### PR TITLE
chore: bump alloy to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,15 +44,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
+checksum = "8dbe4e5e9107bf6854e7550b666ca654ff2027eabf8153913e2e31ac4b089779"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
- "alloy-trie 0.9.4",
+ "alloy-serde 2.0.0",
+ "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
  "auto_impl",
@@ -72,15 +72,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
+checksum = "88fc7bbfb98cf5605a35aadf0ba43a7d9f1608d6f220d05e4fbd5144d3b0b625"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "arbitrary",
  "serde",
 ]
@@ -156,7 +156,30 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.8.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb4919fa34b268842f434bfafa9c09136ab7b1a87ce0dd40a61befa35b5408c"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.0",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -170,12 +193,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13146597a586a4166ac31b192883e08c044272d6b8c43de231ee1f43dd9a115"
+checksum = "adcd754dd6733c3f2d44dd99ddecb7d844428a9b3cdbcafbe65570886bf24b20"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -190,14 +213,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
+checksum = "1e111e22c1a2133e9ebfd9051ea0eaf63559594d2f50d43cbc6762fbb95fc3c2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
- "alloy-serde",
- "alloy-trie 0.9.4",
+ "alloy-serde 2.0.0",
+ "alloy-trie",
  "borsh",
  "serde",
  "serde_with",
@@ -230,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
+checksum = "31b6af6f374c1eeef8ab8dc26232cd440db167322a4207a3debd3d1ee565ca47"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -245,19 +268,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
+checksum = "f0a3f5a7f3678b71d33fcc45b714fab8928dbc647d5aff2145e72032d5c849bb"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -271,14 +294,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
+checksum = "fb50dc1fb0e0b2c8748d5bee1aa7acdd18f9e036311bc93a71d97be624030317"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
@@ -336,22 +359,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
+checksum = "949c0f16a94ae33cdb1139b8dbf9e34d7f26ebfe97962e2a4d620b5f65f48fe4"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2145138f3214928f08cd13da3cb51ef7482b5920d8ac5a02ecd4e38d1a8f6d1e"
+checksum = "301249e3c9e43661cfd7ebbb4746a00af6ce1ef58b5c968451882cd60438417d"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more",
  "serde",
  "serde_with",
@@ -359,15 +387,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
+checksum = "e59bc947935732cae5b072753e5e034c0b70a8b031c2839f45e2659ba07df9ae"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "derive_more",
  "rand 0.8.5",
  "serde",
@@ -376,17 +404,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
+checksum = "cc280a41931bd419af86e9e859dd9726b73313aaa2e479b33c0e344f4b892ddb"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -403,6 +431,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4848831ff994c88b1c32b7df9c4c1c3eedea4b535bde5eb3c421ef0bdc5ac052"
+dependencies = [
+ "alloy-primitives",
  "arbitrary",
  "serde",
  "serde_json",
@@ -410,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
+checksum = "84b8ad9890b212e224291024b1aecfeef72127d27a2f6eebc5e347c40275c4bf"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -425,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
+checksum = "3c67d2372aada343130d41e249b59a3cef29b1678dcd3fd80f1c2c4d6b5318f2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -511,22 +550,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "arrayvec",
- "derive_more",
- "nybbles 0.3.4",
- "serde",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "alloy-trie"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
@@ -537,7 +560,7 @@ dependencies = [
  "arrayvec",
  "derive_arbitrary",
  "derive_more",
- "nybbles 0.4.8",
+ "nybbles",
  "proptest",
  "proptest-derive",
  "serde",
@@ -548,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+checksum = "8d8228b9236479ff16b03041b64b86c2bd4e53da1caa45d59b5868cd1571131e"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1722,7 +1745,7 @@ name = "ef-tests"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -2645,9 +2668,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -2807,9 +2830,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -3023,17 +3046,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.116",
-]
-
-[[package]]
-name = "nybbles"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
-dependencies = [
- "const-hex",
- "serde",
- "smallvec",
 ]
 
 [[package]]
@@ -3808,11 +3820,11 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -3838,16 +3850,16 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-trie 0.9.4",
+ "alloy-trie",
  "auto_impl",
  "derive_more",
  "reth-ethereum-forks",
@@ -3858,15 +3870,15 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1df733d93427eb197cf80a7aaa68bff8949e1b59d34cde1ad410351a24136d"
+checksum = "a29541038ab108b2e9d527c66b565e717e252e4eef6675377fc21f9ba587f792"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-trie 0.9.4",
+ "alloy-trie",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -3879,9 +3891,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14acf8feadf1eed0734d1766b55b6c19a374d4cb140bc862880f96da33e7e5a"
+checksum = "5646d4aff98bd51050fc920bc3ffdff209f2343def9ed31b56eea13c4245c4da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3890,8 +3902,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "eyre",
  "reth-network-types",
@@ -3903,8 +3915,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3916,11 +3928,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -3929,8 +3941,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -3957,8 +3969,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3983,8 +3995,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -4013,10 +4025,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -4028,11 +4040,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -4053,8 +4065,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -4064,11 +4076,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -4080,10 +4092,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -4096,8 +4108,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -4109,11 +4121,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -4123,8 +4135,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -4133,11 +4145,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -4155,11 +4167,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -4175,24 +4187,24 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
- "nybbles 0.4.8",
+ "nybbles",
  "reth-storage-errors",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-execution-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -4207,8 +4219,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "serde",
  "serde_json",
@@ -4217,8 +4229,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -4234,8 +4246,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "bindgen",
  "cc",
@@ -4243,8 +4255,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "metrics",
  "metrics-derive",
@@ -4252,8 +4264,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -4261,8 +4273,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4274,8 +4286,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-eip2124",
  "reth-net-banlist",
@@ -4285,8 +4297,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4302,8 +4314,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -4314,8 +4326,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -4326,11 +4338,11 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -4350,17 +4362,17 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03650bb740d1bca0d974c007248177ae7a7e38c50c9f46eb02292c5d9bc01252"
+checksum = "e96ffdb2ce0cdcd814d39428dc1e9b660c85d85e0b75eb465a1ed0943a48c7bd"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-trie 0.9.4",
+ "alloy-trie",
  "arbitrary",
  "byteorder",
  "bytes",
@@ -4383,11 +4395,11 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -4429,8 +4441,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -4445,8 +4457,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4460,8 +4472,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -4474,8 +4486,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4488,11 +4500,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -4512,10 +4524,10 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -4530,8 +4542,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -4551,8 +4563,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "clap",
  "eyre",
@@ -4568,8 +4580,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "clap",
  "eyre",
@@ -4585,14 +4597,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-trie 0.9.4",
+ "alloy-trie",
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
@@ -4611,22 +4623,22 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-trie 0.9.4",
+ "alloy-serde 2.0.0",
+ "alloy-trie",
  "arbitrary",
  "arrayvec",
  "bytes",
  "derive_more",
  "hash-db",
  "itertools 0.14.0",
- "nybbles 0.4.8",
+ "nybbles",
  "plain_hasher",
  "rayon",
  "reth-codecs",
@@ -4638,8 +4650,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -4658,12 +4670,12 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=adc960162f#adc960162fb960471c98d301fcef4a1bea2abe02"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a511362#a5113622fd0e6af874a79a263dbc11f08cbba548"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-trie 0.9.4",
+ "alloy-trie",
  "auto_impl",
  "rayon",
  "reth-execution-errors",
@@ -4678,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be2e9bda3e45c5d87cfbe811676bfb9cb1f0e6fa82d1dd6a3e8cd996512f236"
+checksum = "3882441cf1d51fe24dfc6df9919e6f17edfdb6b121050bd34348e925e61c7af1"
 dependencies = [
  "zstd",
 ]
@@ -4755,7 +4767,7 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -5377,12 +5389,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5662,9 +5674,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -5677,9 +5689,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6002,7 +6014,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
- "alloy-trie 0.9.4",
+ "alloy-trie",
  "itertools 0.14.0",
  "reth-trie-common",
  "reth-trie-sparse",
@@ -6842,7 +6854,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-trie",
  "arrayvec",
  "bincode",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,31 +44,31 @@ stateless = { path = "crates/stateless" }
 tries = { path = "crates/tries" }
 
 # reth
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f" }
-reth-primitives-traits = { version = "0.1.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f", default-features = false }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f", default-features = false }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f" }
-reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", rev = "adc960162f", default-features = false }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a511362", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a511362", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a511362" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a511362" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "a511362" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a511362", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a511362", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a511362", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a511362" }
+reth-primitives-traits = { version = "0.2.0", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a511362" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a511362", default-features = false }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a511362" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a511362" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a511362", default-features = false }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a511362" }
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", rev = "a511362", default-features = false }
 
 # alloy
-alloy-consensus = { version = "1.8", default-features = false }
-alloy-eips = { version = "1.8", default-features = false }
-alloy-genesis = { version = "1.8", default-features = false }
-alloy-primitives = { version = "1.5.6", default-features = false, features = ["map-foldhash"] }
+alloy-consensus = { version = "2.0.0", default-features = false }
+alloy-eips = { version = "2.0.0", default-features = false }
+alloy-genesis = { version = "2.0.0", default-features = false }
+alloy-primitives = { version = "1.5.6", default-features = false, features = ["map-foldhash", "map-indexmap"] }
 alloy-rlp = { version = "0.3", default-features = false }
-alloy-rpc-types-debug = { version = "1.8", default-features = false }
+alloy-rpc-types-debug = { version = "2.0.0", default-features = false }
 alloy-trie = { version = "0.9", default-features = false }
 
 # revm

--- a/crates/zeth-mpt/Cargo.toml
+++ b/crates/zeth-mpt/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-alloy-trie = { version = "0.8.0", default-features = false, features = ["ethereum"] }
+alloy-trie = { version = "0.9", default-features = false, features = ["ethereum"] }
 alloy-rlp.workspace = true
 alloy-primitives.workspace = true
 

--- a/crates/zeth-mpt/src/mpt/mod.rs
+++ b/crates/zeth-mpt/src/mpt/mod.rs
@@ -52,7 +52,7 @@ impl Trie {
     /// It panics when neither inclusion nor exclusion of the key can be guaranteed.
     #[inline]
     pub fn get(&self, key: impl AsRef<[u8]>) -> Option<&[u8]> {
-        self.0.get(NibbleSlice::from(&Nibbles::unpack(key))).map(|b| b.as_ref())
+        self.0.get(NibbleSlice::from(Nibbles::unpack(key))).map(|b| b.as_ref())
     }
 
     /// Inserts a key-value pair into the trie.
@@ -67,7 +67,7 @@ impl Trie {
     ///   (i.e., the node is represented by a digest and the full node is not available).
     #[inline]
     pub fn insert(&mut self, key: impl AsRef<[u8]>, value: impl Into<Bytes>) {
-        self.0.insert(NibbleSlice::from(&Nibbles::unpack(key)), value.into());
+        self.0.insert(NibbleSlice::from(Nibbles::unpack(key)), value.into());
     }
 
     /// Removes a key-value pair from the trie.
@@ -86,7 +86,7 @@ impl Trie {
     ///   potential issue with the trie's construction.
     #[inline]
     pub fn remove(&mut self, key: impl AsRef<[u8]>) -> bool {
-        self.0.remove(NibbleSlice::from(&Nibbles::unpack(key)))
+        self.0.remove(NibbleSlice::from(Nibbles::unpack(key)))
     }
 
     /// Returns the number of full nodes in the trie.
@@ -252,7 +252,7 @@ impl CachedTrie {
     /// See [`Trie::get`] for detailed documentation.
     #[inline]
     pub fn get(&self, key: impl AsRef<[u8]>) -> Option<&[u8]> {
-        self.inner.get(NibbleSlice::from(&Nibbles::unpack(key))).map(|b| b.as_ref())
+        self.inner.get(NibbleSlice::from(Nibbles::unpack(key))).map(|b| b.as_ref())
     }
 
     /// Inserts a key-value pair into the trie.
@@ -260,7 +260,7 @@ impl CachedTrie {
     /// See [`Trie::insert`] for detailed documentation.
     #[inline]
     pub fn insert(&mut self, key: impl AsRef<[u8]>, value: impl Into<Bytes>) {
-        self.inner.insert(NibbleSlice::from(&Nibbles::unpack(key)), value.into());
+        self.inner.insert(NibbleSlice::from(Nibbles::unpack(key)), value.into());
         self.hash = None;
     }
 
@@ -269,7 +269,7 @@ impl CachedTrie {
     /// See [`Trie::remove`] for detailed documentation.
     #[inline]
     pub fn remove(&mut self, key: impl AsRef<[u8]>) -> bool {
-        if !self.inner.remove(NibbleSlice::from(&Nibbles::unpack(key))) {
+        if !self.inner.remove(NibbleSlice::from(Nibbles::unpack(key))) {
             return false;
         }
         self.hash = None;

--- a/crates/zeth-mpt/src/mpt/nibbles.rs
+++ b/crates/zeth-mpt/src/mpt/nibbles.rs
@@ -12,59 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A zero-cost abstraction for handling nibbles (4-bit values) as byte slices.
+//! A zero-cost abstraction for handling nibbles (4-bit values).
 //!
-//! This module provides `NibbleSlice`, a wrapper around `&[u8]` that guarantees
-//! each byte represents a valid nibble (0-15). It offers efficient operations
-//! for working with nibble data without runtime overhead.
+//! This module provides `NibbleSlice`, a `Copy` wrapper around `Nibbles` that
+//! offers efficient operations for working with nibble data.
 
-use alloy_primitives::hex;
 use alloy_trie::Nibbles;
-use core::{fmt, ops::Deref};
+use core::fmt;
 
-/// A slice of bytes representing nibbles.
-#[derive(Clone, Copy)]
-pub(super) struct NibbleSlice<'a>(&'a [u8]);
+/// A slice of nibbles backed by an owned `Nibbles` value.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) struct NibbleSlice(Nibbles);
 
-impl Deref for NibbleSlice<'_> {
-    type Target = [u8];
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
-}
-
-impl fmt::Debug for NibbleSlice<'_> {
+impl fmt::Debug for NibbleSlice {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Nibbles(0x{})", hex::encode(self.as_slice()))
+        write!(f, "{:?}", self.0)
     }
 }
 
-impl<'a> From<&'a Nibbles> for NibbleSlice<'a> {
-    /// Creates a `NibbleSlice` from a `Nibbles` reference.
+impl From<&Nibbles> for NibbleSlice {
     #[inline]
-    fn from(nibbles: &'a Nibbles) -> Self {
-        Self(nibbles.as_slice())
+    fn from(nibbles: &Nibbles) -> Self {
+        Self(*nibbles)
     }
 }
 
-impl From<NibbleSlice<'_>> for Nibbles {
+impl From<Nibbles> for NibbleSlice {
+    #[inline]
+    fn from(nibbles: Nibbles) -> Self {
+        Self(nibbles)
+    }
+}
+
+impl From<NibbleSlice> for Nibbles {
     /// Converts a `NibbleSlice` back into a `Nibbles`.
     #[inline]
-    fn from(slice: NibbleSlice<'_>) -> Self {
-        Nibbles::from_nibbles_unchecked(slice.0)
+    fn from(slice: NibbleSlice) -> Self {
+        slice.0
     }
 }
 
 #[allow(dead_code)]
-impl<'a> NibbleSlice<'a> {
-    #[inline]
-    pub(super) const fn as_slice(&self) -> &'a [u8] {
-        self.0
-    }
-
+impl NibbleSlice {
     #[inline]
     pub(super) const fn len(&self) -> usize {
         self.0.len()
@@ -76,36 +66,48 @@ impl<'a> NibbleSlice<'a> {
     }
 
     #[inline]
+    pub(super) fn as_nibbles(&self) -> &Nibbles {
+        &self.0
+    }
+
+    #[inline]
     pub(super) fn join(&self, other: impl Into<Self>) -> Nibbles {
-        let other = other.into();
-        let mut nibbles = Nibbles::with_capacity(self.len() + other.len());
-        nibbles.extend_from_slice_unchecked(self.as_slice());
-        nibbles.extend_from_slice_unchecked(other.as_slice());
-        nibbles
+        self.0.join(&other.into().0)
     }
 
     #[inline]
     pub(super) fn split_first(&self) -> Option<(u8, Self)> {
-        self.0.split_first().map(|(nib, tail)| (*nib, Self(tail)))
+        if self.0.is_empty() {
+            None
+        } else {
+            let nib = self.0.get_unchecked(0);
+            Some((nib, Self(self.0.slice(1..))))
+        }
     }
 
     #[inline]
-    pub(super) fn strip_prefix(&self, prefix: &[u8]) -> Option<Self> {
-        self.0.strip_prefix(prefix).map(Self)
+    pub(super) fn strip_prefix(&self, prefix: &Nibbles) -> Option<Self> {
+        if self.0.starts_with(prefix) {
+            Some(Self(self.0.slice(prefix.len()..)))
+        } else {
+            None
+        }
     }
 
     #[inline]
-    pub(super) fn strip_suffix(&self, suffix: &[u8]) -> Option<Self> {
-        self.0.strip_suffix(suffix).map(Self)
+    pub(super) fn strip_suffix(&self, suffix: &Nibbles) -> Option<Self> {
+        if self.0.ends_with(suffix) {
+            Some(Self(self.0.slice(..self.0.len() - suffix.len())))
+        } else {
+            None
+        }
     }
 
     /// Splits `self` and `other` at the first nibble that differs.
     #[inline]
     pub(super) fn split_common_prefix(&self, other: impl Into<Self>) -> (Self, Self, Self) {
-        let (a, b) = (self.0, other.into().0);
-        let mid = a.iter().zip(b).take_while(|&(x, y)| x == y).count();
-        // SAFETY: mid is the length of the common prefix: mid <= a.len() ∧ mid <= b.len()
-        let (common, a_tail) = unsafe { a.split_at_unchecked(mid) };
-        (Self(common), Self(a_tail), Self(unsafe { b.split_at_unchecked(mid).1 }))
+        let other = other.into().0;
+        let mid = self.0.common_prefix_length(&other);
+        (Self(self.0.slice(..mid)), Self(self.0.slice(mid..)), Self(other.slice(mid..)))
     }
 }

--- a/crates/zeth-mpt/src/mpt/node.rs
+++ b/crates/zeth-mpt/src/mpt/node.rs
@@ -81,10 +81,10 @@ impl<M> Eq for Node<M> {}
 
 impl<M: Memoization> Node<M> {
     /// Retrieves the value associated with a given key.
-    pub(super) fn get(&self, key: NibbleSlice<'_>) -> Option<&Bytes> {
+    pub(super) fn get(&self, key: NibbleSlice) -> Option<&Bytes> {
         match self {
             Node::Null => None,
-            Node::Leaf(prefix, value, _) if prefix == key.as_slice() => Some(value),
+            Node::Leaf(prefix, value, _) if prefix == key.as_nibbles() => Some(value),
             Node::Leaf(..) => None,
             Node::Extension(prefix, child, _) => {
                 key.strip_prefix(prefix).and_then(|tail| child.get(tail))
@@ -102,14 +102,14 @@ impl<M: Memoization> Node<M> {
     }
 
     /// Inserts a key-value pair into the trie.
-    pub(super) fn insert(&mut self, key: NibbleSlice<'_>, value: Bytes) {
+    pub(super) fn insert(&mut self, key: NibbleSlice, value: Bytes) {
         assert!(!value.is_empty());
         match self {
             Node::Null => {
                 *self = Node::Leaf(key.into(), value, M::default());
             }
             Node::Leaf(prefix, leaf_val, cache) => {
-                let (common, key_rem, prefix_rem) = key.split_common_prefix(&*prefix);
+                let (common, key_rem, prefix_rem) = key.split_common_prefix(*prefix);
                 if common.len() == prefix.len() && common.len() == key.len() {
                     *leaf_val = value;
                     cache.clear();
@@ -143,7 +143,7 @@ impl<M: Memoization> Node<M> {
                 };
             }
             Node::Extension(prefix, child, cache) => {
-                let (common, key_rem, prefix_rem) = key.split_common_prefix(&*prefix);
+                let (common, key_rem, prefix_rem) = key.split_common_prefix(*prefix);
                 if common.len() == prefix.len() {
                     child.insert(key_rem, value);
                     cache.clear();
@@ -153,17 +153,14 @@ impl<M: Memoization> Node<M> {
                 }
 
                 let mut children = Children::default();
-                match prefix_rem.as_slice() {
-                    [nib] => children.insert(*nib, mem::take(child)),
-                    [nib, tail @ ..] => {
-                        // SAFETY: `tail` is a slice of `prefix` and thus only contains nibbles
-                        let prefix = Nibbles::from_nibbles_unchecked(tail);
-                        children.insert(
-                            *nib,
-                            Node::Extension(prefix, mem::take(child), M::default()).into(),
-                        );
-                    }
-                    _ => unreachable!(), // mid < prefix.len()
+                let (nib, tail) = prefix_rem.split_first().expect("mid < prefix.len()");
+                if tail.is_empty() {
+                    children.insert(nib, mem::take(child));
+                } else {
+                    children.insert(
+                        nib,
+                        Node::Extension(tail.into(), mem::take(child), M::default()).into(),
+                    );
                 }
                 match key_rem.split_first() {
                     Some((nib, tail)) => {
@@ -197,16 +194,16 @@ impl<M: Memoization> Node<M> {
     }
 
     /// Removes a key-value pair from the trie.
-    pub(super) fn remove(&mut self, key: NibbleSlice<'_>) -> bool {
+    pub(super) fn remove(&mut self, key: NibbleSlice) -> bool {
         match self {
             Node::Null => false,
-            Node::Leaf(prefix, ..) if prefix == key.as_slice() => {
+            Node::Leaf(prefix, ..) if prefix == key.as_nibbles() => {
                 *self = Node::Null;
                 true
             }
             Node::Leaf(..) => false,
             Node::Extension(prefix, child, cache) => {
-                if !key.strip_prefix(&*prefix).is_some_and(|tail| child.remove(tail)) {
+                if !key.strip_prefix(prefix).is_some_and(|tail| child.remove(tail)) {
                     return false;
                 }
                 cache.clear();
@@ -215,11 +212,11 @@ impl<M: Memoization> Node<M> {
                 match **child {
                     Node::Null => *self = Node::Null,
                     Node::Leaf(ref extension, ref mut value, _) => {
-                        prefix.extend_from_slice(extension);
+                        prefix.extend(extension);
                         *self = Node::Leaf(mem::take(prefix), mem::take(value), M::default())
                     }
                     Node::Extension(ref extension, ref mut child, _) => {
-                        prefix.extend_from_slice(extension);
+                        prefix.extend(extension);
                         *self = Node::Extension(mem::take(prefix), mem::take(child), M::default())
                     }
                     Node::Branch(..) => {}
@@ -244,20 +241,19 @@ impl<M: Memoization> Node<M> {
                 if let Some((nib, only_child)) = children.take_single_child() {
                     match *only_child {
                         // if the only child is a leaf, prepend the corresponding nib to it
-                        Node::Leaf(mut extension, value, _) => {
-                            // SAFETY: `take_single_child` always returns a nibble
-                            extension.as_mut_vec_unchecked().insert(0, nib);
-                            *self = Node::Leaf(extension, value, M::default());
+                        Node::Leaf(extension, value, _) => {
+                            let mut prefix = Nibbles::from_nibbles_unchecked([nib]);
+                            prefix.extend(&extension);
+                            *self = Node::Leaf(prefix, value, M::default());
                         }
                         // if the only child is an extension, prepend the corresponding nib to it
-                        Node::Extension(mut extension, child, ..) => {
-                            // SAFETY: `take_single_child` always returns a nibble
-                            extension.as_mut_vec_unchecked().insert(0, nib);
-                            *self = Node::Extension(extension, child, M::default());
+                        Node::Extension(extension, child, ..) => {
+                            let mut prefix = Nibbles::from_nibbles_unchecked([nib]);
+                            prefix.extend(&extension);
+                            *self = Node::Extension(prefix, child, M::default());
                         }
                         // if the only child is a branch, convert to an extension
                         Node::Branch(..) => {
-                            // SAFETY: `take_single_child` always returns a nibble
                             let prefix = Nibbles::from_nibbles_unchecked([nib]);
                             *self = Node::Extension(prefix, only_child, M::default());
                         }

--- a/crates/zeth-mpt/src/mpt/orphan.rs
+++ b/crates/zeth-mpt/src/mpt/orphan.rs
@@ -70,7 +70,7 @@ impl Trie {
         I: IntoIterator<Item = T>,
         T: AsRef<[u8]>,
     {
-        self.0.resolve_orphan(NibbleSlice::from(&Nibbles::unpack(key)), proof)
+        self.0.resolve_orphan(NibbleSlice::from(Nibbles::unpack(key)), proof)
     }
 }
 
@@ -85,7 +85,7 @@ impl CachedTrie {
         I: IntoIterator<Item = T>,
         T: AsRef<[u8]>,
     {
-        self.inner.resolve_orphan(NibbleSlice::from(&Nibbles::unpack(key)), proof)
+        self.inner.resolve_orphan(NibbleSlice::from(Nibbles::unpack(key)), proof)
     }
 }
 
@@ -93,7 +93,7 @@ impl<M: Memoization + Clone> Node<M> {
     /// Attempts to resolve orphaned branch children caused by removing a key-value pair.
     pub(super) fn resolve_orphan<T: AsRef<[u8]>>(
         &mut self,
-        key: NibbleSlice<'_>,
+        key: NibbleSlice,
         proof: impl IntoIterator<Item = T>,
     ) -> Result<(), Error> {
         assert!(self.get(key).is_some(), "key not contained");
@@ -101,7 +101,7 @@ impl<M: Memoization + Clone> Node<M> {
         let Some((diverging, unmatched)) = other.diverging(key) else {
             return Ok(());
         };
-        let matched = key.strip_suffix(&unmatched).unwrap();
+        let matched = key.strip_suffix(unmatched.as_nibbles()).unwrap();
 
         match diverging {
             Node::Null => {
@@ -114,7 +114,7 @@ impl<M: Memoization + Clone> Node<M> {
                 // split the first nibble which used to belong to the Branch
                 let (idx, suffix) = unmatched.split_first().expect("empty unmatched key");
                 // this can only be an orphan, if it is currently a Digest child of a Branch
-                if !self.is_branch_with_digest(&matched.join(common), idx) {
+                if !self.is_branch_with_digest(matched.join(common), idx) {
                     return Ok(());
                 }
 
@@ -130,7 +130,7 @@ impl<M: Memoization + Clone> Node<M> {
                 // split the first nibble which used to belong to the Branch
                 let (idx, suffix) = unmatched.split_first().expect("empty unmatched key");
                 // this can only be an orphan, if it is currently a Digest child of a Branch
-                if !self.is_branch_with_digest(&matched.join(common), idx) {
+                if !self.is_branch_with_digest(matched.join(common), idx) {
                     return Ok(());
                 }
 
@@ -149,7 +149,7 @@ impl<M: Memoization + Clone> Node<M> {
                     // the path to the orphan corresponds exactly to the path of the Extension-child
                     let orphan_prefix = matched.join(prefix);
                     // maybe the trie already contains a node with this prefix
-                    if self.contains_prefix(&orphan_prefix) {
+                    if self.contains_prefix(orphan_prefix) {
                         // in this case, the removal will not fail and nothing needs to be resolved
                         return Ok(());
                     }
@@ -176,11 +176,11 @@ impl<M: Memoization + Clone> Node<M> {
     ///
     /// If the key is present in the trie, this method returns `None`. Otherwise, it returns the
     /// node where the search for the key would fail, along with the unmatched portion of the key.
-    fn diverging<'a>(&'a self, key: NibbleSlice<'a>) -> Option<(&'a Node<M>, NibbleSlice<'a>)> {
+    fn diverging(&self, key: NibbleSlice) -> Option<(&Node<M>, NibbleSlice)> {
         match self {
             Node::Null => Some((&Node::Null, key)),
 
-            Node::Leaf(prefix, ..) if prefix == key.as_slice() => None,
+            Node::Leaf(prefix, ..) if prefix == key.as_nibbles() => None,
             Node::Leaf(..) => Some((self, key)),
 
             Node::Extension(prefix, child, _) => {
@@ -199,7 +199,7 @@ impl<M: Memoization + Clone> Node<M> {
         }
     }
 
-    fn contains_prefix<'a>(&'a self, key: impl Into<NibbleSlice<'a>>) -> bool {
+    fn contains_prefix(&self, key: impl Into<NibbleSlice>) -> bool {
         match self.diverging(key.into()) {
             None => true,                                 // contains the prefix as a key
             Some((Node::Digest(_), _)) => false,          // prefix not resolved
@@ -208,7 +208,7 @@ impl<M: Memoization + Clone> Node<M> {
     }
 
     /// Returns whether the node at key is a Branch which has a Digest child at idx.
-    fn is_branch_with_digest<'a>(&'a self, key: impl Into<NibbleSlice<'a>>, idx: u8) -> bool {
+    fn is_branch_with_digest(&self, key: impl Into<NibbleSlice>, idx: u8) -> bool {
         match self.diverging(key.into()) {
             // match only if, the node found is a `Node::Branch` and the *entire* key was consumed
             Some((Node::Branch(children, ..), unmatched)) if unmatched.is_empty() => {

--- a/crates/zeth-mpt/src/mpt/rkyv.rs
+++ b/crates/zeth-mpt/src/mpt/rkyv.rs
@@ -76,13 +76,13 @@ impl ArchiveWith<Nibbles> for NibblesDef {
     type Resolver = VecResolver;
 
     fn resolve_with(nibbles: &Nibbles, resolver: Self::Resolver, out: Place<Self::Archived>) {
-        ArchivedVec::resolve_from_slice(nibbles, resolver, out);
+        ArchivedVec::resolve_from_slice(&nibbles.to_vec(), resolver, out);
     }
 }
 
 impl<S: Fallible + Allocator + Writer + ?Sized> SerializeWith<Nibbles, S> for NibblesDef {
     fn serialize_with(nibbles: &Nibbles, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
-        ArchivedVec::serialize_from_slice(nibbles, serializer)
+        ArchivedVec::serialize_from_slice(&nibbles.to_vec(), serializer)
     }
 }
 
@@ -93,7 +93,7 @@ where
 {
     fn deserialize_with(f: &ArchivedVec<u8>, deserializer: &mut D) -> Result<Nibbles, D::Error> {
         let vec = <ArchivedVec<u8> as Deserialize<Vec<u8>, D>>::deserialize(f, deserializer)?;
-        Ok(Nibbles::from_vec_unchecked(vec))
+        Ok(Nibbles::from_nibbles_unchecked(vec))
     }
 }
 

--- a/crates/zeth-mpt/src/mpt/rlp.rs
+++ b/crates/zeth-mpt/src/mpt/rlp.rs
@@ -409,19 +409,28 @@ fn encode_list_header(payload_length: usize) -> Vec<u8> {
 
 #[inline]
 fn decode_path(buf: &mut &[u8]) -> alloy_rlp::Result<(Nibbles, bool)> {
-    let path = Nibbles::unpack(Header::decode_bytes(buf, false)?);
-    if path.len() < 2 {
+    let compact = Header::decode_bytes(buf, false)?;
+    if compact.is_empty() {
         return Err(alloy_rlp::Error::InputTooShort);
     }
-    let (is_leaf, odd_nibbles) = match path[0] {
+    let (is_leaf, odd_len) = match compact[0] >> 4 {
         0b0000 => (false, false),
         0b0001 => (false, true),
         0b0010 => (true, false),
         0b0011 => (true, true),
         _ => return Err(alloy_rlp::Error::Custom("node is not an extension or leaf")),
     };
-    let prefix = if odd_nibbles { &path[1..] } else { &path[2..] };
-    Ok((Nibbles::from_nibbles_unchecked(prefix), is_leaf))
+    // Strip the HP prefix: for odd length, the first nibble of the key is in the low nibble
+    // of the first byte; for even length, skip the first byte entirely.
+    let nibbles = if odd_len {
+        let first = compact[0] & 0x0f;
+        let mut n = Nibbles::from_nibbles_unchecked([first]);
+        n.extend(&Nibbles::unpack(&compact[1..]));
+        n
+    } else {
+        Nibbles::unpack(&compact[1..])
+    };
+    Ok((nibbles, is_leaf))
 }
 
 fn encode_list<B, T>(values: &[B]) -> Vec<u8>

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -23,6 +23,7 @@ use reth_provider::{
 };
 use reth_revm::{State, database::StateProviderDatabase, witness::ExecutionWitnessRecord};
 use reth_trie::{HashedPostState, KeccakKeyHasher, StateRoot};
+use reth_trie_common::ExecutionWitnessMode;
 use reth_trie_db::{
     DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory, LegacyKeyAdapter,
 };
@@ -321,7 +322,7 @@ where
 
         let output = executor
             .execute_with_state_closure_always(&(*block).clone(), |statedb: &State<_>| {
-                witness_record.record_executed_state(statedb);
+                witness_record.record_executed_state(statedb, ExecutionWitnessMode::default());
             })
             .map_err(|err| Error::block_failed(block_number, program_inputs.clone(), err))?;
 
@@ -330,8 +331,12 @@ where
             .map_err(|err| Error::block_failed(block_number, program_inputs.clone(), err))?;
 
         // Generate the stateless witness
-        let exec_witness =
-            witness_record.into_execution_witness(&state_provider, &provider, block_number)?;
+        let exec_witness = witness_record.into_execution_witness(
+            &state_provider,
+            &provider,
+            block_number,
+            ExecutionWitnessMode::default(),
+        )?;
 
         program_inputs.push((block.clone(), exec_witness));
 

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -115,6 +115,8 @@ impl From<Header> for SealedHeader {
             excess_blob_gas: value.excess_blob_gas.map(|v| v.to::<u64>()),
             parent_beacon_block_root: value.parent_beacon_block_root,
             requests_hash: value.requests_hash,
+            block_access_list_hash: None,
+            slot_number: None,
         };
         Self::new(header, value.hash)
     }


### PR DESCRIPTION
## Summary
- Bump alloy crates (consensus, eips, genesis, rpc-types-debug) from 1.8 to 2.0.0
- Bump reth dependencies to latest main (rev `a511362`)
- Bump `reth-primitives-traits` to 0.2.0
- Bump `alloy-trie` in zeth-mpt from 0.8 to 0.9