### PR TITLE
feat(testing): add BALs as part of the run outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5403,6 +5403,7 @@ name = "stateless"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",

--- a/README.md
+++ b/README.md
@@ -29,13 +29,17 @@ The primary entry point is `stateless_validation`:
 ```rust
 use stateless::{stateless_validation, ExecutionWitness};
 
-let (block_hash, output) = stateless_validation(
+let validation = stateless_validation(
     block,
     public_keys,
     witness,
     chain_spec,
     evm_config,
 )?;
+
+let block_hash = validation.block_hash;
+let output = validation.execution_output;
+let block_access_list = validation.block_access_list;
 ```
 
 ## `no_std`

--- a/crates/stateless/Cargo.toml
+++ b/crates/stateless/Cargo.toml
@@ -19,6 +19,7 @@ tries.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-consensus.workspace = true
+alloy-eips.workspace = true
 alloy-rpc-types-debug.workspace = true
 alloy-genesis = { workspace = true, features = ["serde-bincode-compat"] }
 

--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -45,6 +45,8 @@ pub use recover_block::recover_block_with_public_keys;
 #[doc(inline)]
 pub use tries::StatelessTrie;
 #[doc(inline)]
+pub use validation::StatelessValidationOutput;
+#[doc(inline)]
 pub use validation::stateless_validation;
 #[doc(inline)]
 pub use validation::stateless_validation_recovered;

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -11,6 +11,7 @@ use alloc::{
     vec::Vec,
 };
 use alloy_consensus::{BlockHeader, Header};
+use alloy_eips::eip7928::BlockAccessList;
 use alloy_primitives::{B256, keccak256};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_consensus::ConsensusError;
@@ -125,6 +126,17 @@ impl From<StatelessTrieError> for StatelessValidationError {
     }
 }
 
+/// Output of successful stateless block validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatelessValidationOutput {
+    /// Hash of the validated block.
+    pub block_hash: B256,
+    /// Execution output produced while validating the block.
+    pub execution_output: BlockExecutionOutput<EthereumReceipt>,
+    /// Block access list produced during execution, if available.
+    pub block_access_list: Option<BlockAccessList>,
+}
+
 /// Performs stateless validation of a block using the provided witness data.
 pub fn stateless_validation<ChainSpec, E>(
     current_block: Block,
@@ -132,7 +144,7 @@ pub fn stateless_validation<ChainSpec, E>(
     witness: ExecutionWitness,
     chain_spec: Arc<ChainSpec>,
     evm_config: E,
-) -> Result<(B256, BlockExecutionOutput<EthereumReceipt>), StatelessValidationError>
+) -> Result<StatelessValidationOutput, StatelessValidationError>
 where
     ChainSpec: Send + Sync + EthChainSpec<Header = Header> + EthereumHardforks + Debug,
     E: ConfigureEvm<Primitives = EthPrimitives> + Clone + 'static,
@@ -153,7 +165,7 @@ pub fn stateless_validation_with_trie<T, ChainSpec, E>(
     witness: ExecutionWitness,
     chain_spec: Arc<ChainSpec>,
     evm_config: E,
-) -> Result<(B256, BlockExecutionOutput<EthereumReceipt>), StatelessValidationError>
+) -> Result<StatelessValidationOutput, StatelessValidationError>
 where
     T: StatelessTrie,
     ChainSpec: Send + Sync + EthChainSpec<Header = Header> + EthereumHardforks + Debug,
@@ -175,7 +187,7 @@ pub fn stateless_validation_recovered<ChainSpec, E>(
     witness: ExecutionWitness,
     chain_spec: Arc<ChainSpec>,
     evm_config: E,
-) -> Result<(B256, BlockExecutionOutput<EthereumReceipt>), StatelessValidationError>
+) -> Result<StatelessValidationOutput, StatelessValidationError>
 where
     ChainSpec: Send + Sync + EthChainSpec<Header = Header> + EthereumHardforks + Debug,
     E: ConfigureEvm<Primitives = EthPrimitives> + Clone + 'static,
@@ -194,7 +206,7 @@ pub fn stateless_validation_recovered_with_trie<T, ChainSpec, E>(
     witness: ExecutionWitness,
     chain_spec: Arc<ChainSpec>,
     evm_config: E,
-) -> Result<(B256, BlockExecutionOutput<EthereumReceipt>), StatelessValidationError>
+) -> Result<StatelessValidationOutput, StatelessValidationError>
 where
     T: StatelessTrie,
     ChainSpec: Send + Sync + EthChainSpec<Header = Header> + EthereumHardforks + Debug,
@@ -266,7 +278,11 @@ where
         });
     }
 
-    Ok((current_block.hash_slow(), output))
+    Ok(StatelessValidationOutput {
+        block_hash: current_block.hash_slow(),
+        execution_output: output,
+        block_access_list,
+    })
 }
 
 fn validate_block_consensus<ChainSpec>(


### PR DESCRIPTION
This PR adds constructed BALs as part of the test run output.

This will be useful for https://github.com/eth-act/ere-guests were we use `stateless` testing framework to extract some required items for constructing `ExecutionPayload` from `Block`s.

In partiuclar, we already used the `Requests` since is a required sidecar of `ExecutionPayload`. Now with BALs, we need the raw BALs data since is a new field from `ExecutionPayload` (the block only has the BALs hash).

