### PR TITLE
build: support rv64im zkVM target via lower-atomic pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,16 @@ jobs:
         run: ./scripts/run_ef_tests.sh ${{ matrix.trie }}
 
   no-std:
-    name: no_std (RISC-V)
+    name: no_std (RISC-V rv64im)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          targets: riscv32imac-unknown-none-elf
+          components: rust-src
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: Build stateless for riscv32imac
+      - name: Build stateless for riscv64im
         run: ./scripts/check_no_std.sh

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ let block_access_list = validation.block_access_list;
 
 ## `no_std`
 
-The `stateless` crate is `#![no_std]` compatible and builds for RISC-V targets (`riscv32imac-unknown-none-elf`), making it suitable for use in zkVM environments.
+The `stateless` crate is `#![no_std]` compatible and builds for the 64-bit RISC-V target (`riscv64im-unknown-none-elf`), making it suitable for use in zkVM environments. Because upstream dependencies currently require atomics, it must be built using the custom target specification provided in `targets/riscv64im-unknown-none-elf.json`.
+
+> **Note:** The build temporarily relies on the LLVM `lower-atomic` pass
+> to lower atomic instructions into non-atomic equivalents.
 
 ## Running EF tests
 

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-target=riscv32imac-unknown-none-elf
+target=targets/riscv64im-unknown-none-elf.json
 
-cmd=(cargo +stable build --no-default-features --target "$target" -p stateless)
+# Required to prevent __atomic_* references from ending up in the final rlib.
+export RUSTFLAGS="-C passes=lower-atomic"
+
+cmd=(
+  cargo +nightly build
+  --no-default-features
+  --target "$target"
+  -Zbuild-std=core,alloc
+  -Zjson-target-spec
+  -p stateless
+)
 
 echo "Running: ${cmd[*]}"
 "${cmd[@]}"

--- a/targets/riscv64im-unknown-none-elf.json
+++ b/targets/riscv64im-unknown-none-elf.json
@@ -1,0 +1,29 @@
+{
+  "arch": "riscv64",
+  "code-model": "medium",
+  "cpu": "generic-rv64",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+m",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "lp64",
+  "llvm-target": "riscv64-unknown-none-elf",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": "Bare RISC-V (RV64IM ISA)",
+    "host_tools": false,
+    "std": false,
+    "tier": 2
+  },
+  "os": "none",
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "supported-sanitizers": [
+    "shadow-call-stack",
+    "kernel-address"
+  ],
+  "target-pointer-width": 64
+}


### PR DESCRIPTION
addresses #4

Adds support for compiling to `rv64im` (without atomics) by utilizing the LLVM `lower-atomic` pass. 

- Adds custom target `riscv64im-unknown-none-elf.json` (features: `+m`).
- Uses `RUSTFLAGS="-C passes=lower-atomic"` to lower atomics in upstream dependencies (safe for single-threaded zkVMs).
- Updates `check_no_std.sh` and CI to use `nightly` and `-Zbuild-std=core,alloc`.