### PR TITLE
feat: harden stateless validation

### DIFF
--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -247,7 +247,7 @@ where
     ChainSpec: Send + Sync + EthChainSpec<Header = Header> + EthereumHardforks + Debug,
     E: ConfigureEvm<Primitives = EthPrimitives> + Clone + 'static,
 {
-    let mut ancestor_headers: Vec<_> = witness
+    let ancestor_headers: Vec<_> = witness
         .headers
         .iter()
         .map(|bytes| {
@@ -257,7 +257,6 @@ where
                 .map_err(|_| StatelessValidationError::HeaderDeserializationFailed)
         })
         .collect::<Result<_, _>>()?;
-    ancestor_headers.sort_by_key(|header| header.number());
 
     let count = ancestor_headers.len();
     if count > BLOCKHASH_ANCESTOR_LIMIT {

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -11,7 +11,9 @@ use alloc::{
     vec::Vec,
 };
 use alloy_consensus::{BlockHeader, Header};
-use alloy_eips::eip7928::BlockAccessList;
+use alloy_eips::eip7928::{
+    BlockAccessList, ITEM_COST, compute_block_access_list_hash, total_bal_items,
+};
 use alloy_primitives::{B256, keccak256};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_consensus::ConsensusError;
@@ -83,6 +85,15 @@ pub enum StatelessValidationError {
     /// Error during consensus validation of the block.
     #[error("consensus validation failed: {0}")]
     ConsensusValidationFailed(#[from] ConsensusError),
+
+    /// Error when the block access list exceeds the per-block item gas limit (EIP-7928).
+    #[error("block access list exceeds gas limit, {items} items exceeds limit of {limit}")]
+    BlockAccessListGasLimitExceeded {
+        /// The number of block access list items produced during execution.
+        items: u64,
+        /// The maximum number of items allowed, the block gas limit divided by the per item cost.
+        limit: u64,
+    },
 
     /// Error during stateless state root calculation.
     #[error("stateless state root calculation failed")]
@@ -269,13 +280,35 @@ where
 
     let db = WitnessDatabase::new(&trie, bytecode, ancestor_hashes);
 
-    let executor = evm_config.executor(db);
-    let output = executor
-        .execute(&current_block)
+    let mut executor = evm_config.executor(db);
+    let result = executor
+        .execute_one(&current_block)
         .map_err(|e| StatelessValidationError::StatelessExecutionFailed(e.to_string()))?;
 
-    validate_block_post_execution(&current_block, &chain_spec, &output.result, None, None)
-        .map_err(StatelessValidationError::ConsensusValidationFailed)?;
+    let block_access_list = executor.take_bal();
+
+    // Validate the block access list gas limit constraint.
+    if let Some(bal) = block_access_list.as_ref() {
+        let items = total_bal_items(bal.as_slice());
+        let limit = current_block.sealed_header().gas_limit() / ITEM_COST as u64;
+        if items > limit {
+            return Err(StatelessValidationError::BlockAccessListGasLimitExceeded { items, limit });
+        }
+    }
+
+    let block_access_list_hash = block_access_list.as_deref().map(compute_block_access_list_hash);
+
+    let mut state = executor.into_state();
+    let output = BlockExecutionOutput { state: state.take_bundle(), result };
+
+    validate_block_post_execution(
+        &current_block,
+        &chain_spec,
+        &output.result,
+        None,
+        block_access_list_hash,
+    )
+    .map_err(StatelessValidationError::ConsensusValidationFailed)?;
 
     let hashed_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(&output.state.state);
     let state_root = trie.calculate_state_root(hashed_state)?;
@@ -289,10 +322,7 @@ where
     Ok(StatelessValidationOutput {
         block_hash: current_block.hash_slow(),
         execution_output: output,
-        // TODO: populate once reth mainline wires revm's BAL builder (track
-        // https://github.com/paradigmxyz/reth/pull/22881). Requires
-        // State::builder().with_bal_builder() + bump_bal_index() + take_built_alloy_bal().
-        block_access_list: None,
+        block_access_list,
     })
 }
 

--- a/crates/tries/src/zeth.rs
+++ b/crates/tries/src/zeth.rs
@@ -48,15 +48,15 @@ impl<T: alloy_rlp::Decodable + alloy_rlp::Encodable> RlpTrie<T> {
     }
 
     pub fn get(&self, key: impl AsRef<[u8]>) -> alloy_rlp::Result<Option<T>> {
-        self.inner.get(key).map(alloy_rlp::decode_exact).transpose()
+        self.inner.try_get(key)?.map(alloy_rlp::decode_exact).transpose()
     }
 
     pub fn insert(&mut self, key: impl AsRef<[u8]>, value: T) {
         self.inner.insert(key, alloy_rlp::encode(value));
     }
 
-    pub fn remove(&mut self, key: impl AsRef<[u8]>) -> bool {
-        self.inner.remove(key)
+    pub fn remove(&mut self, key: impl AsRef<[u8]>) -> alloy_rlp::Result<bool> {
+        self.inner.try_remove(key)
     }
 
     pub fn hash(&mut self) -> B256 {
@@ -79,9 +79,10 @@ pub struct SparseState {
 
 impl SparseState {
     /// Removes an account from the state.
-    fn remove_account(&mut self, hashed_address: &B256) {
-        self.state.remove(hashed_address);
+    fn remove_account(&mut self, hashed_address: &B256) -> alloy_rlp::Result<()> {
+        self.state.remove(hashed_address)?;
         self.storages.get_mut().remove(hashed_address);
+        Ok(())
     }
 
     /// Clears the storage of an account.
@@ -182,12 +183,16 @@ impl StatelessTrie for SparseState {
 
             // apply storage changes before computing the storage root
             let storage_root = match state.storages.get(&hashed_address) {
-                None => self.storage_trie_mut(hashed_address).unwrap().hash(),
+                None => self
+                    .storage_trie_mut(hashed_address)
+                    .map_err(|_| StatelessTrieError::StatelessStateRootCalculationFailed)?
+                    .hash(),
                 Some(storage) => {
                     let storage_trie = if storage.wiped {
                         self.clear_storage(hashed_address)
                     } else {
-                        self.storage_trie_mut(hashed_address).unwrap()
+                        self.storage_trie_mut(hashed_address)
+                            .map_err(|_| StatelessTrieError::StatelessStateRootCalculationFailed)?
                     };
 
                     // apply all state modifications
@@ -199,7 +204,9 @@ impl StatelessTrie for SparseState {
                     // removals must happen last, otherwise unresolved orphans might still exist
                     for (hashed_key, value) in &storage.storage {
                         if value.is_zero() {
-                            storage_trie.remove(hashed_key);
+                            storage_trie.remove(hashed_key).map_err(|_| {
+                                StatelessTrieError::StatelessStateRootCalculationFailed
+                            })?;
                         }
                     }
 
@@ -216,7 +223,10 @@ impl StatelessTrie for SparseState {
             };
             self.state.insert(hashed_address, account);
         }
-        removed_accounts.iter().for_each(|hashed_address| self.remove_account(hashed_address));
+        for hashed_address in &removed_accounts {
+            self.remove_account(hashed_address)
+                .map_err(|_| StatelessTrieError::StatelessStateRootCalculationFailed)?;
+        }
 
         Ok(self.state.hash())
     }

--- a/crates/zeth-mpt/src/mpt/mod.rs
+++ b/crates/zeth-mpt/src/mpt/mod.rs
@@ -52,7 +52,7 @@ impl Trie {
     /// It panics when neither inclusion nor exclusion of the key can be guaranteed.
     #[inline]
     pub fn get(&self, key: impl AsRef<[u8]>) -> Option<&[u8]> {
-        self.0.get(NibbleSlice::from(Nibbles::unpack(key))).map(|b| b.as_ref())
+        self.0.get(NibbleSlice::from(Nibbles::unpack(key))).unwrap().map(|b| b.as_ref())
     }
 
     /// Inserts a key-value pair into the trie.
@@ -86,7 +86,7 @@ impl Trie {
     ///   potential issue with the trie's construction.
     #[inline]
     pub fn remove(&mut self, key: impl AsRef<[u8]>) -> bool {
-        self.0.remove(NibbleSlice::from(Nibbles::unpack(key)))
+        self.0.remove(NibbleSlice::from(Nibbles::unpack(key))).unwrap()
     }
 
     /// Returns the number of full nodes in the trie.
@@ -252,7 +252,16 @@ impl CachedTrie {
     /// See [`Trie::get`] for detailed documentation.
     #[inline]
     pub fn get(&self, key: impl AsRef<[u8]>) -> Option<&[u8]> {
-        self.inner.get(NibbleSlice::from(Nibbles::unpack(key))).map(|b| b.as_ref())
+        self.try_get(key).unwrap()
+    }
+
+    /// Retrieves the value associated with a key, returning an error when a required node is
+    /// unresolved (omitted from the witness).
+    ///
+    /// See [`Trie::get`] for detailed documentation.
+    #[inline]
+    pub fn try_get(&self, key: impl AsRef<[u8]>) -> alloy_rlp::Result<Option<&[u8]>> {
+        Ok(self.inner.get(NibbleSlice::from(Nibbles::unpack(key)))?.map(|b| b.as_ref()))
     }
 
     /// Inserts a key-value pair into the trie.
@@ -269,11 +278,20 @@ impl CachedTrie {
     /// See [`Trie::remove`] for detailed documentation.
     #[inline]
     pub fn remove(&mut self, key: impl AsRef<[u8]>) -> bool {
-        if !self.inner.remove(NibbleSlice::from(Nibbles::unpack(key))) {
-            return false;
+        self.try_remove(key).unwrap()
+    }
+
+    /// Removes a key-value pair, returning an error when a node required to complete the removal is
+    /// unresolved (omitted from the witness).
+    ///
+    /// See [`Trie::remove`] for detailed documentation.
+    #[inline]
+    pub fn try_remove(&mut self, key: impl AsRef<[u8]>) -> alloy_rlp::Result<bool> {
+        if !self.inner.remove(NibbleSlice::from(Nibbles::unpack(key)))? {
+            return Ok(false);
         }
         self.hash = None;
-        true
+        Ok(true)
     }
 
     /// Returns the number of full nodes in the trie.

--- a/crates/zeth-mpt/src/mpt/node.rs
+++ b/crates/zeth-mpt/src/mpt/node.rs
@@ -81,24 +81,29 @@ impl<M> Eq for Node<M> {}
 
 impl<M: Memoization> Node<M> {
     /// Retrieves the value associated with a given key.
-    pub(super) fn get(&self, key: NibbleSlice) -> Option<&Bytes> {
-        match self {
+    pub(super) fn get(&self, key: NibbleSlice) -> alloy_rlp::Result<Option<&Bytes>> {
+        Ok(match self {
             Node::Null => None,
             Node::Leaf(prefix, value, _) if prefix == key.as_nibbles() => Some(value),
             Node::Leaf(..) => None,
-            Node::Extension(prefix, child, _) => {
-                key.strip_prefix(prefix).and_then(|tail| child.get(tail))
-            }
+            Node::Extension(prefix, child, _) => match key.strip_prefix(prefix) {
+                Some(tail) => return child.get(tail),
+                None => None,
+            },
             Node::Branch(children, _) => match key.split_first() {
                 Some((nib, tail)) => {
                     // SAFETY: `key` is a `NibbleSlice` and thus only contains values < 0xf
                     let child = unsafe { children.get_unchecked(nib) };
-                    child.and_then(|node| node.get(tail))
+                    match child {
+                        Some(node) => return node.get(tail),
+                        None => None,
+                    }
                 }
                 None => None, // branch nodes don't have values in our MPT version
             },
-            Node::Digest(_) => panic!("MPT: Unresolved node access"),
-        }
+            // The witness omitted this node
+            Node::Digest(_) => return Err(alloy_rlp::Error::Custom("MPT: unresolved node access")),
+        })
     }
 
     /// Inserts a key-value pair into the trie.
@@ -194,8 +199,11 @@ impl<M: Memoization> Node<M> {
     }
 
     /// Removes a key-value pair from the trie.
-    pub(super) fn remove(&mut self, key: NibbleSlice) -> bool {
-        match self {
+    ///
+    /// Returns an error when a node required to complete the removal was omitted from the witness
+    /// (represented as a digest) rather than panicking, so the validator can reject the block.
+    pub(super) fn remove(&mut self, key: NibbleSlice) -> alloy_rlp::Result<bool> {
+        Ok(match self {
             Node::Null => false,
             Node::Leaf(prefix, ..) if prefix == key.as_nibbles() => {
                 *self = Node::Null;
@@ -203,8 +211,12 @@ impl<M: Memoization> Node<M> {
             }
             Node::Leaf(..) => false,
             Node::Extension(prefix, child, cache) => {
-                if !key.strip_prefix(prefix).is_some_and(|tail| child.remove(tail)) {
-                    return false;
+                let removed = match key.strip_prefix(prefix) {
+                    Some(tail) => child.remove(tail)?,
+                    None => false,
+                };
+                if !removed {
+                    return Ok(false);
                 }
                 cache.clear();
 
@@ -220,7 +232,7 @@ impl<M: Memoization> Node<M> {
                         *self = Node::Extension(mem::take(prefix), mem::take(child), M::default())
                     }
                     Node::Branch(..) => {}
-                    Node::Digest(_) => unreachable!(), // child.remove() would have panicked
+                    Node::Digest(_) => unreachable!(), // child.remove() would have errored
                 }
                 true
             }
@@ -228,13 +240,13 @@ impl<M: Memoization> Node<M> {
                 match key.split_first() {
                     Some((nib, tail)) => match children.entry(nib) {
                         Entry::Occupied(mut entry) => {
-                            if !entry.get_mut().remove(tail) {
-                                return false;
+                            if !entry.get_mut().remove(tail)? {
+                                return Ok(false);
                             }
                         }
-                        Entry::Vacant(_) => return false,
+                        Entry::Vacant(_) => return Ok(false),
                     },
-                    None => return false, // branch nodes don't have values in our MPT version
+                    None => return Ok(false), // branch nodes don't have values in our MPT version
                 };
                 cache.clear();
 
@@ -257,14 +269,16 @@ impl<M: Memoization> Node<M> {
                             let prefix = Nibbles::from_nibbles_unchecked([nib]);
                             *self = Node::Extension(prefix, only_child, M::default());
                         }
-                        Node::Digest(_) => panic!("MPT: Unresolved node access"),
+                        Node::Digest(_) => {
+                            return Err(alloy_rlp::Error::Custom("MPT: unresolved node access"))
+                        }
                         Node::Null => unreachable!(), // children does not contain any Node::Null
                     }
                 }
                 true
             }
-            Node::Digest(_) => panic!("MPT: Unresolved node access"),
-        }
+            Node::Digest(_) => return Err(alloy_rlp::Error::Custom("MPT: unresolved node access")),
+        })
     }
 
     /// Returns the number of full nodes in the trie.

--- a/crates/zeth-mpt/src/mpt/orphan.rs
+++ b/crates/zeth-mpt/src/mpt/orphan.rs
@@ -96,7 +96,7 @@ impl<M: Memoization + Clone> Node<M> {
         key: NibbleSlice,
         proof: impl IntoIterator<Item = T>,
     ) -> Result<(), Error> {
-        assert!(self.get(key).is_some(), "key not contained");
+        assert!(self.get(key)?.is_some(), "key not contained");
         let other = Node::from_rlp(proof)?;
         let Some((diverging, unmatched)) = other.diverging(key) else {
             return Ok(());


### PR DESCRIPTION
## What changed

Ports the remaining behavior changes from `han0110/stateless` on top of the reth `v2.3.0` bump:

- returns validation errors for unresolved zeth MPT witness nodes instead of panicking on get/remove paths
- captures the EIP-7928 block access list from execution, enforces the BAL item gas limit, passes the computed BAL hash into post-execution validation, and returns the BAL in `StatelessValidationOutput`
- preserves the supplied ancestor header order so malformed or unordered witness headers are rejected instead of sorted into place

## Why

These changes make stateless validation stricter and safer for malformed witnesses while wiring the BAL output that is available after the reth `v2.3.0` API update.

## Impact

Incomplete witnesses now fail as validation errors instead of process panics, BAL mismatches are validated as part of post-execution checks, and witness header ordering becomes part of the accepted input contract.

This PR currently includes the dependency bump from #28 because the BAL and executor changes depend on the reth `v2.3.0` APIs. It should be reviewed after #28 and can be rebased once that lands.