### PR TITLE
perf(stateless): avoid eager witness bytecode analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6291,7 +6291,6 @@ dependencies = [
  "itertools 0.14.0",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-bytecode",
  "revm-database-interface",
  "thiserror",
  "zeth-mpt",

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -275,7 +275,7 @@ where
 
     validate_block_consensus(chain_spec.clone(), &current_block, parent)?;
 
-    let (mut trie, bytecode) = T::new(&witness, parent.state_root)?;
+    let (mut trie, bytecode) = T::new(witness, parent.state_root)?;
 
     let db = WitnessDatabase::new(&trie, bytecode, ancestor_hashes);
 

--- a/crates/stateless/src/witness_db.rs
+++ b/crates/stateless/src/witness_db.rs
@@ -2,7 +2,7 @@
 //! specifically designed for stateless execution environments.
 
 use alloc::{collections::btree_map::BTreeMap, format};
-use alloy_primitives::{Address, B256, U256, map::B256IndexMap};
+use alloy_primitives::{Address, B256, Bytes, U256, map::B256IndexMap};
 use revm_bytecode::Bytecode;
 use revm_database_interface::Database;
 use revm_state::AccountInfo;
@@ -27,7 +27,7 @@ where
     block_hashes_by_block_number: BTreeMap<u64, B256>,
     /// Map of code hashes to bytecode.
     /// Used to fetch contract code needed during execution.
-    bytecode: B256IndexMap<Bytecode>,
+    bytecode: B256IndexMap<Bytes>,
     /// The sparse Merkle Patricia Trie containing account and storage state.
     /// This is used to provide account/storage values during EVM execution.
     trie: &'a T,
@@ -52,7 +52,7 @@ where
     ///    the block limit.
     pub(crate) const fn new(
         trie: &'a T,
-        bytecode: B256IndexMap<Bytecode>,
+        bytecode: B256IndexMap<Bytes>,
         ancestor_hashes: BTreeMap<u64, B256>,
     ) -> Self {
         Self { trie, block_hashes_by_block_number: ancestor_hashes, bytecode }
@@ -93,9 +93,10 @@ where
     ///
     /// Returns an error if the bytecode for the given hash is not found in the map.
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
-        self.bytecode.get(&code_hash).cloned().ok_or_else(|| {
+        let raw = self.bytecode.get(&code_hash).cloned().ok_or_else(|| {
             WitnessDbError::TrieWitness(format!("bytecode for {code_hash} not found"))
-        })
+        })?;
+        Ok(Bytecode::new_raw(raw))
     }
 
     /// Get block hash by block number from the provided ancestor hashes map.

--- a/crates/tries/Cargo.toml
+++ b/crates/tries/Cargo.toml
@@ -19,7 +19,6 @@ alloy-trie.workspace = true
 itertools.workspace = true
 reth-trie-common.workspace = true
 reth-trie-sparse.workspace = true
-revm-bytecode.workspace = true
 revm-database-interface.workspace = true
 thiserror.workspace = true
 zeth-mpt = { path = "../zeth-mpt" }

--- a/crates/tries/src/default.rs
+++ b/crates/tries/src/default.rs
@@ -1,6 +1,6 @@
 use crate::{StatelessTrie, StatelessTrieError, WitnessDbError};
 use alloc::{collections::VecDeque, format, vec::Vec};
-use alloy_primitives::{Address, B256, U256, keccak256, map::B256IndexMap};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256, map::B256IndexMap};
 use alloy_rlp::Decodable;
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_trie::{EMPTY_ROOT_HASH, TrieAccount, nodes::TrieNode};
@@ -9,7 +9,6 @@ use reth_trie_common::{
     BranchNodeMasks, DecodedMultiProofV2, HashedPostState, Nibbles, ProofTrieNodeV2,
 };
 use reth_trie_sparse::{RevealableSparseTrie, SparseStateTrie, errors::SparseStateTrieResult};
-use revm_bytecode::Bytecode;
 
 /// `StatelessSparseTrie` structure for usage during stateless validation
 #[derive(Debug)]
@@ -23,9 +22,9 @@ impl StatelessSparseTrie {
     /// Note: Currently this method does not check that the `ExecutionWitness`
     /// is complete for all of the preimage keys.
     pub fn new(
-        witness: &ExecutionWitness,
+        witness: ExecutionWitness,
         pre_state_root: B256,
-    ) -> Result<(Self, B256IndexMap<Bytecode>), StatelessTrieError> {
+    ) -> Result<(Self, B256IndexMap<Bytes>), StatelessTrieError> {
         verify_execution_witness(witness, pre_state_root)
             .map(|(inner, bytecode)| (Self { inner }, bytecode))
     }
@@ -99,9 +98,9 @@ impl StatelessSparseTrie {
 
 impl StatelessTrie for StatelessSparseTrie {
     fn new(
-        witness: &ExecutionWitness,
+        witness: ExecutionWitness,
         pre_state_root: B256,
-    ) -> Result<(Self, B256IndexMap<Bytecode>), StatelessTrieError> {
+    ) -> Result<(Self, B256IndexMap<Bytes>), StatelessTrieError> {
         Self::new(witness, pre_state_root)
     }
 
@@ -135,21 +134,21 @@ impl StatelessTrie for StatelessSparseTrie {
 /// If the roots do not match, it returns an error indicating the witness is invalid
 /// for the given `pre_state_root` (see [`StatelessTrieError::PreStateRootMismatch`]).
 fn verify_execution_witness(
-    witness: &ExecutionWitness,
+    witness: ExecutionWitness,
     pre_state_root: B256,
-) -> Result<(SparseStateTrie, B256IndexMap<Bytecode>), StatelessTrieError> {
+) -> Result<(SparseStateTrie, B256IndexMap<Bytes>), StatelessTrieError> {
     let mut trie = SparseStateTrie::new();
     let mut bytecode = B256IndexMap::default();
 
     // Build a hash-indexed map of witness nodes.
     let mut nodes_by_hash = B256IndexMap::default();
-    for rlp_encoded in &witness.state {
-        let hash = keccak256(rlp_encoded);
-        nodes_by_hash.insert(hash, rlp_encoded.clone());
+    for rlp_encoded in witness.state {
+        let hash = keccak256(&rlp_encoded);
+        nodes_by_hash.insert(hash, rlp_encoded);
     }
-    for rlp_encoded in &witness.codes {
-        let hash = keccak256(rlp_encoded);
-        bytecode.insert(hash, Bytecode::new_raw(rlp_encoded.clone()));
+    for rlp_encoded in witness.codes {
+        let hash = keccak256(&rlp_encoded);
+        bytecode.insert(hash, rlp_encoded);
     }
 
     // Build a DecodedMultiProofV2 by walking the witness from the root.
@@ -293,7 +292,7 @@ fn calculate_state_root(
             storage_trie.wipe()?;
         }
 
-        // Apply slot‑level changes
+        // Apply slot-level changes
         for (hashed_slot, value) in
             storage.storage.into_iter().sorted_unstable_by_key(|(slot, _)| *slot)
         {

--- a/crates/tries/src/lib.rs
+++ b/crates/tries/src/lib.rs
@@ -19,19 +19,18 @@ pub mod zeth;
 
 pub use error::{StatelessTrieError, WitnessDbError};
 
-use alloy_primitives::{Address, B256, U256, map::B256IndexMap};
+use alloy_primitives::{Address, B256, Bytes, U256, map::B256IndexMap};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_trie::TrieAccount;
 use reth_trie_common::HashedPostState;
-use revm_bytecode::Bytecode;
 
 /// Trait for trie implementations that can be used for stateless validation.
 pub trait StatelessTrie: core::fmt::Debug {
     /// Initialize the trie using the [`ExecutionWitness`].
     fn new(
-        witness: &ExecutionWitness,
+        witness: ExecutionWitness,
         pre_state_root: B256,
-    ) -> Result<(Self, B256IndexMap<Bytecode>), StatelessTrieError>
+    ) -> Result<(Self, B256IndexMap<Bytes>), StatelessTrieError>
     where
         Self: Sized;
 

--- a/crates/tries/src/zeth.rs
+++ b/crates/tries/src/zeth.rs
@@ -24,7 +24,6 @@ use alloy_primitives::{
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_trie::{EMPTY_ROOT_HASH, TrieAccount};
 use reth_trie_common::HashedPostState;
-use revm_bytecode::Bytecode;
 use zeth_mpt::CachedTrie;
 
 /// Zero-overhead helper for tries that only contain RLP encoded data.
@@ -116,23 +115,19 @@ impl SparseState {
 impl StatelessTrie for SparseState {
     /// Initialize the stateless trie using the `ExecutionWitness`.
     fn new(
-        witness: &ExecutionWitness,
+        witness: ExecutionWitness,
         pre_state_root: B256,
-    ) -> Result<(Self, B256IndexMap<Bytecode>), StatelessTrieError> {
+    ) -> Result<(Self, B256IndexMap<Bytes>), StatelessTrieError> {
         // fist, hash all the RLP nodes once
         let rlp_by_digest: B256IndexMap<_> =
-            witness.state.iter().map(|rlp| (keccak256(rlp), rlp.clone())).collect();
+            witness.state.into_iter().map(|rlp| (keccak256(&rlp), rlp)).collect();
 
         // construct the state trie from the witness data and the given state root
         let state = RlpTrie::from_prehashed(pre_state_root, &rlp_by_digest)
             .map_err(|_| StatelessTrieError::WitnessRevealFailed { pre_state_root })?;
 
         // hash all the supplied bytecode
-        let bytecode = witness
-            .codes
-            .iter()
-            .map(|code| (keccak256(code), Bytecode::new_raw(code.clone())))
-            .collect();
+        let bytecode = witness.codes.into_iter().map(|code| (keccak256(&code), code)).collect();
 
         Ok((
             Self { state, storages: RefCell::new(B256IndexMap::default()), rlp_by_digest },


### PR DESCRIPTION
## Summary

Keeps witness bytecode as raw `Bytes` during trie construction and converts it to `Bytecode` only when `WitnessDatabase::code_by_hash` is called.

The trie constructors now consume `ExecutionWitness`, so witness state/code entries can be moved into their hash-indexed maps instead of cloned. This avoids eager bytecode construction for witness code that execution never requests.

## Benchmark

Full SP1 cycle benchmark for `zkevm-fixtures-10m-osaka-full` (Osaka 10M), using the Reth guest with public-key verification enabled, `reth-v2.1.0`, `sp1-v6.1.0`, and `RAYON_NUM_THREADS=4`. The run used the same fixture set as the clean Reth baseline and completed with `0` output mismatches and `0` crashes after serially repairing the parallel crash records in the same output folder.

This PR reduces the clean Reth full-run total by `57,694,594` cycles.
