### PR TITLE
ci(guest): build release artifacts on demand

### DIFF
--- a/.github/workflows/reth-guests.yml
+++ b/.github/workflows/reth-guests.yml
@@ -2,17 +2,12 @@ name: Reth guest artifacts
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "reth-guest-v*"
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/docs/guest-releases.md
+++ b/docs/guest-releases.md
@@ -27,7 +27,7 @@ The three guest packages are independent Cargo workspaces with committed
 lockfiles. A build fails if its lockfile changes or if the compiler does not
 produce a non-empty ELF and verification key.
 
-Pull requests and pushes to `main` build all three artifacts without write
+Manual workflow runs build and smoke-test all three artifacts without write
 permissions. Pushing a `reth-guest-v*` tag runs the same matrix, creates
 checksums, attests the artifacts, and creates a GitHub release after every
 build and smoke test succeeds.


### PR DESCRIPTION
Builds and smoke-tests Reth guest artifacts only for `reth-guest-v*` tags or explicit manual dispatches.

This avoids producing retained ELF/VK workflow artifacts on every pull request and `main` push while preserving an on-demand dry run before tagging.