### PR TITLE
feat: update ere to v0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,18 +2072,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 
 [[package]]
 name = "ere-prover-core"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -2098,8 +2098,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-api"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 dependencies = [
  "prost",
  "serde",
@@ -2108,8 +2108,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-client"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 dependencies = [
  "bincode 2.0.1",
  "ere-prover-core",
@@ -2120,16 +2120,16 @@ dependencies = [
 
 [[package]]
 name = "ere-util-tokio"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "ere-verifier-core"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 dependencies = [
  "auto_impl",
  "ere-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,9 +89,9 @@ revm-state = { version = "42.0.0", default-features = false }
 zkvm-interface = { git = "https://github.com/eth-act/zkvm-standards", rev = "282cd356c3a0498416bb0619f9c8a347ce9933fb" }
 
 # Ere
-ere-platform-core = { git = "https://github.com/eth-act/ere", rev = "552595938b48884d87cfada24f29d39223695c1e" }
-ere-server-client = { git = "https://github.com/eth-act/ere", rev = "552595938b48884d87cfada24f29d39223695c1e" }
-ere-util-tokio = { git = "https://github.com/eth-act/ere", rev = "552595938b48884d87cfada24f29d39223695c1e" }
+ere-platform-core = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa" }
+ere-server-client = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa" }
+ere-util-tokio = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa" }
 
 # ssz
 libssz = { version = "0.3.0", default-features = false, features = ["alloc"] }

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -1206,13 +1206,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",

--- a/bin/stateless-validator-reth/openvm/Cargo.toml
+++ b/bin/stateless-validator-reth/openvm/Cargo.toml
@@ -13,7 +13,7 @@ alloy-primitives = { version = "1.6.1", default-features = false, features = [
 ] }
 
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "552595938b48884d87cfada24f29d39223695c1e", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa", features = [
     "std",
     "zkvm-accelerator",
 ] }

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -1270,13 +1270,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 dependencies = [
  "ere-platform-core",
  "libzkevm",
@@ -1939,8 +1939,8 @@ dependencies = [
 
 [[package]]
 name = "libzkevm"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "bls12_381",
  "k256 0.13.4 (git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.2.0)",
@@ -3544,8 +3544,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -3554,8 +3554,8 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -3568,8 +3568,8 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -3580,8 +3580,8 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -3594,24 +3594,24 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "p3-symmetric",
 ]
@@ -3627,8 +3627,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -3638,8 +3638,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "bincode",
  "blake3",
@@ -3661,8 +3661,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.1"
-source = "git+https://github.com/han0110/sp1?rev=8564a70ea1952826fc0926eba5a3ce62af53ffac#8564a70ea1952826fc0926eba5a3ce62af53ffac"
+version = "6.4.0"
+source = "git+https://github.com/han0110/sp1?rev=7929b001303feb6803ce1214557d5ab1f17eee84#7929b001303feb6803ce1214557d5ab1f17eee84"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/bin/stateless-validator-reth/sp1/Cargo.toml
+++ b/bin/stateless-validator-reth/sp1/Cargo.toml
@@ -13,7 +13,7 @@ alloy-primitives = { version = "1.6.1", default-features = false, features = [
 ] }
 
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", rev = "552595938b48884d87cfada24f29d39223695c1e" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa" }
 
 # local
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", default-features = false, features = [
@@ -22,7 +22,7 @@ stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", 
 
 [patch.crates-io]
 # FIXME: Remove the patch once https://github.com/succinctlabs/sp1/pull/2865 is merged and released.
-sp1-lib = { git = "https://github.com/han0110/sp1", rev = "8564a70ea1952826fc0926eba5a3ce62af53ffac" }
+sp1-lib = { git = "https://github.com/han0110/sp1", rev = "7929b001303feb6803ce1214557d5ab1f17eee84" }
 
 # Temporary until the revm release containing bluealloy/revm#3855 is published.
 alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "065a125cde3a5c69990323aecab97ce4ed048237" }
@@ -44,10 +44,10 @@ revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88f
 revm-state = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
 
 [patch."https://github.com/succinctlabs/sp1.git"]
-sp1-lib = { git = "https://github.com/han0110/sp1", rev = "8564a70ea1952826fc0926eba5a3ce62af53ffac" }
-sp1-primitives = { git = "https://github.com/han0110/sp1", rev = "8564a70ea1952826fc0926eba5a3ce62af53ffac" }
-sp1-zkvm = { git = "https://github.com/han0110/sp1", rev = "8564a70ea1952826fc0926eba5a3ce62af53ffac" }
-sp1-libzkevm = { git = "https://github.com/han0110/sp1", rev = "8564a70ea1952826fc0926eba5a3ce62af53ffac", package = "libzkevm" }
+sp1-lib = { git = "https://github.com/han0110/sp1", rev = "7929b001303feb6803ce1214557d5ab1f17eee84" }
+sp1-primitives = { git = "https://github.com/han0110/sp1", rev = "7929b001303feb6803ce1214557d5ab1f17eee84" }
+sp1-zkvm = { git = "https://github.com/han0110/sp1", rev = "7929b001303feb6803ce1214557d5ab1f17eee84" }
+sp1-libzkevm = { git = "https://github.com/han0110/sp1", rev = "7929b001303feb6803ce1214557d5ab1f17eee84", package = "libzkevm" }
 
 [profile.release]
 codegen-units = 1

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -942,11 +942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "circuit"
-version = "1.0.0-alpha"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v1.0.0-alpha#4b9f758fabc4955cac20af837019ccc31b803a46"
-
-[[package]]
 name = "clang-sys"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1017,15 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1325,13 +1329,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.15.0"
-source = "git+https://github.com/eth-act/ere?rev=552595938b48884d87cfada24f29d39223695c1e#552595938b48884d87cfada24f29d39223695c1e"
+version = "0.16.2"
+source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
 dependencies = [
  "ere-platform-core",
  "ziskos",
@@ -1351,17 +1355,6 @@ checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "fields"
-version = "1.0.0-alpha"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
-dependencies = [
- "cfg-if",
- "num-bigint",
- "paste",
- "serde",
 ]
 
 [[package]]
@@ -1813,11 +1806,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lib-c"
-version = "1.0.0-alpha"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v1.0.0-alpha#4b9f758fabc4955cac20af837019ccc31b803a46"
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,24 +2227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precompiles-helpers"
-version = "1.0.0-alpha"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v1.0.0-alpha#4b9f758fabc4955cac20af837019ccc31b803a46"
-dependencies = [
- "ark-bls12-381 0.5.0",
- "ark-bn254 0.5.0",
- "ark-ff 0.5.0",
- "ark-secp256k1",
- "ark-secp256r1",
- "cfg-if",
- "circuit",
- "crunchy",
- "lib-c",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,12 +2277,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "proofman-verifier"
-version = "1.0.0-alpha"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
+name = "proofman-fields"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea663e7b8fbeaba6a3d0e6046fd7d85250186cdc2fac56ce102bfe8bfcfdf0d"
 dependencies = [
- "fields",
+ "cfg-if",
+ "num-bigint",
+ "paste",
+ "proofman-starks-lib-c",
+ "serde",
+]
+
+[[package]]
+name = "proofman-starks-lib-c"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebeb94ceceb5009296fa5603ea710861ca262af8dcdcd43c243707aec9d6726"
+dependencies = [
+ "crossbeam-channel",
+ "proofman-starks-src",
+]
+
+[[package]]
+name = "proofman-starks-src"
+version = "1.1.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f652a3899833633da4829ee714b7d8ecdece399929bfd6673a471ecf0ce3227"
+
+[[package]]
+name = "proofman-verifier"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e578aca4212b4e4d083d62c54c74cbf2aa01926e15a76d6b0c9c70a4b98e2719"
+dependencies = [
  "num-traits",
+ "proofman-fields",
  "serde",
 ]
 
@@ -3311,7 +3311,7 @@ dependencies = [
  "serde_with",
  "thiserror",
  "tries",
- "zkvm-interface 0.1.0",
+ "zkvm-interface",
 ]
 
 [[package]]
@@ -3345,7 +3345,7 @@ dependencies = [
  "stateless-validator-common",
  "thiserror",
  "tries",
- "zkvm-interface 0.1.0",
+ "zkvm-interface",
 ]
 
 [[package]]
@@ -3806,22 +3806,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "zisk-circuit"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28185dd7ca65e2ffebc9a19992239aa6e379ac95dab73ec90d34344f59719355"
+
+[[package]]
 name = "zisk-definitions"
-version = "1.0.0-alpha"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v1.0.0-alpha#4b9f758fabc4955cac20af837019ccc31b803a46"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7078fc25f294bfcdf4f9089f113b60f1efc6c8a55518d6ea24093aa7c59c2a"
+
+[[package]]
+name = "zisk-lib-c"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc8968509c571acf9334322c06301b2bf9443054982a82893af957a65143b8ba"
+
+[[package]]
+name = "zisk-precomp-helpers"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3416ae98910aacd8b615e04088f25f00181f1765dae7b24e0a66ebad78b8e8b8"
+dependencies = [
+ "ark-bls12-381 0.5.0",
+ "ark-bn254 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-secp256k1",
+ "ark-secp256r1",
+ "cfg-if",
+ "crunchy",
+ "num-bigint",
+ "num-traits",
+ "zisk-circuit",
+ "zisk-lib-c",
+]
 
 [[package]]
 name = "zisk-verifier"
-version = "1.0.0-alpha"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v1.0.0-alpha#4b9f758fabc4955cac20af837019ccc31b803a46"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ffde99de17184da25de7823ad37f57d8d5aaa75bc89335fc8e13ed8dc521627"
 dependencies = [
  "proofman-verifier",
 ]
 
 [[package]]
+name = "zisk-zkvm-interface"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5d7999bdac04dd84053c34946d18a1cc7b452b860d46f2025defe48a06c42d"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "ziskos"
-version = "1.0.0-alpha"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v1.0.0-alpha#4b9f758fabc4955cac20af837019ccc31b803a46"
+version = "1.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2edae833e0d199eca7145fabe0bcdf1fc9d380f68833f280d9b45d6307b1f14e"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ec 0.5.0",
@@ -3831,15 +3874,13 @@ dependencies = [
  "bincode",
  "blst",
  "cfg-if",
- "fields",
  "getrandom 0.2.17",
  "lazy_static",
- "lib-c",
  "libc",
  "num-bigint",
  "num-integer",
  "num-traits",
- "precompiles-helpers",
+ "proofman-fields",
  "rand 0.8.7",
  "ripemd 0.1.3",
  "secp256k1 0.31.1",
@@ -3847,22 +3888,16 @@ dependencies = [
  "sha2 0.10.9",
  "tiny-keccak",
  "zisk-definitions",
+ "zisk-lib-c",
+ "zisk-precomp-helpers",
  "zisk-verifier",
- "zkvm-interface 1.0.0-alpha",
+ "zisk-zkvm-interface",
 ]
 
 [[package]]
 name = "zkvm-interface"
 version = "0.1.0"
 source = "git+https://github.com/eth-act/zkvm-standards?rev=282cd356c3a0498416bb0619f9c8a347ce9933fb#282cd356c3a0498416bb0619f9c8a347ce9933fb"
-dependencies = [
- "bindgen",
-]
-
-[[package]]
-name = "zkvm-interface"
-version = "1.0.0-alpha"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v1.0.0-alpha#4b9f758fabc4955cac20af837019ccc31b803a46"
 dependencies = [
  "bindgen",
 ]

--- a/bin/stateless-validator-reth/zisk/Cargo.toml
+++ b/bin/stateless-validator-reth/zisk/Cargo.toml
@@ -16,7 +16,7 @@ alloy-primitives = { version = "1.6.1", default-features = false, features = [
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "552595938b48884d87cfada24f29d39223695c1e", default-features = false, features = [
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa", default-features = false, features = [
     "inputcpy",
 ] }
 

--- a/docs/guest-releases.md
+++ b/docs/guest-releases.md
@@ -6,8 +6,8 @@ for OpenVM, SP1, and ZisK under these names:
 
 ```text
 stateless-validator-reth-openvm-v2.1.0-preview.elf
-stateless-validator-reth-sp1-v6.3.1.elf
-stateless-validator-reth-zisk-v1.0.0-alpha.elf
+stateless-validator-reth-sp1-v6.4.0.elf
+stateless-validator-reth-zisk-v1.1.0-alpha.elf
 ```
 
 Each ELF has a verification key with the same basename and a `.vk` extension.
@@ -15,7 +15,7 @@ Releases also contain `SHA256SUMS` and GitHub artifact attestations.
 
 ## Build
 
-The build scripts use digest-pinned ERE v0.15.0 compiler and server images:
+The build scripts use digest-pinned ERE v0.16.2 compiler and server images:
 
 ```bash
 scripts/guests/build.sh openvm output
@@ -38,7 +38,7 @@ After downloading a release, verify checksums and GitHub's signed provenance:
 
 ```bash
 sha256sum --check SHA256SUMS
-gh attestation verify stateless-validator-reth-sp1-v6.3.1.elf \
+gh attestation verify stateless-validator-reth-sp1-v6.4.0.elf \
   --repo paradigmxyz/stateless
 ```
 

--- a/scripts/guests/build.sh
+++ b/scripts/guests/build.sh
@@ -20,8 +20,17 @@ OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 LOCKFILE="$REPO_ROOT/bin/stateless-validator-reth/$ZKVM/Cargo.lock"
 CONTAINER_GUEST_DIR="/stateless/bin/stateless-validator-reth/$ZKVM"
 
+compiler_options=()
+case "$ZKVM" in
+    zisk)
+        # The ZisK RV64IMA target leaves unaligned scalar access off by default.
+        compiler_options+=(-e "ERE_RUSTFLAGS=-C target-feature=+unaligned-scalar-mem")
+        ;;
+esac
+
 docker run --rm \
     -e RUST_LOG=info \
+    "${compiler_options[@]}" \
     --mount "type=bind,src=$REPO_ROOT,dst=/stateless" \
     --mount "type=bind,src=$LOCKFILE,dst=$CONTAINER_GUEST_DIR/Cargo.lock,readonly" \
     --mount "type=bind,src=$OUTPUT_DIR,dst=/output" \

--- a/scripts/guests/config.sh
+++ b/scripts/guests/config.sh
@@ -4,18 +4,18 @@ guest_config() {
     case "${1:?zkVM name is required}" in
         openvm)
             ZKVM_VERSION="v2.1.0-preview"
-            COMPILER_IMAGE="ghcr.io/eth-act/ere/ere-compiler-openvm@sha256:6afea444a0470641d1bdc7aae43b80f022cc55af72c12d64c8f0e9419f195cf1"
-            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-openvm@sha256:57d912b9531b40839774b4d4d81a4a7d22e76ef0a8283ec58c8de4f7fb78cbfb"
+            COMPILER_IMAGE="ghcr.io/eth-act/ere/ere-compiler-openvm@sha256:1d673fa4063aed15e039a0fe8cf5915d96e8fb7bd9bd7d2587d1ccf2c21e7eb1"
+            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-openvm@sha256:d56f5f59f1560bc2b58e84165accb8dc6586596ca1b9ff53b99862560f7b563c"
             ;;
         sp1)
-            ZKVM_VERSION="v6.3.1"
-            COMPILER_IMAGE="ghcr.io/eth-act/ere/ere-compiler-sp1@sha256:0bf8394ba9487b1124e5ea6abc7debf3afc459168dcd51e8127c423fe6f5689a"
-            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-sp1@sha256:170f6641707015dddc5a90e7ac71a511a3ccbff16082d785e13c21fde67e0744"
+            ZKVM_VERSION="v6.4.0"
+            COMPILER_IMAGE="ghcr.io/eth-act/ere/ere-compiler-sp1@sha256:9c4f7fd724e1537415fa03622f006e0ac2544676100fe90e7b2363a88c67170b"
+            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-sp1@sha256:561ba9d13e0f4f198c57ad8c76b8320f691635275f6567bcb27b36d4e4159af4"
             ;;
         zisk)
-            ZKVM_VERSION="v1.0.0-alpha"
-            COMPILER_IMAGE="ghcr.io/eth-act/ere/ere-compiler-zisk@sha256:e5fea7055c6f4f005d1c1e0fd90e20abc171c0dc00ca0b75af7272004eb761e8"
-            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-zisk@sha256:1fd910170d25290d547a16600927b9735d619354f0cab1c306ef06412e09d46e"
+            ZKVM_VERSION="v1.1.0-alpha"
+            COMPILER_IMAGE="ghcr.io/eth-act/ere/ere-compiler-zisk@sha256:0ba9ef646d4359094e6043573530314b6717fab8c3b8bd96a7aa6329d39d172a"
+            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-zisk@sha256:4d00a96890a26dc54b523e537e9c1b25a26cf18d166bd3614fc97bbd09317091"
             ;;
         *)
             echo "unsupported zkVM: $1" >&2


### PR DESCRIPTION
- Base on #39
- Update `ere` dependencies to rev `8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa` ([`v0.16.2`](https://github.com/eth-act/ere/tree/v0.16.2))
  - Update `zisk` to `v1.1.0-alpha`
  - Update `sp1` to `v6.4.0`
    - Update `sp1` patches to rev `7929b001303feb6803ce1214557d5ab1f17eee84` ([`patch/v6.4.0/libzkevm`](https://github.com/han0110/sp1/tree/patch/v6.4.0/libzkevm))
- Update the `ere-compiler` image tag to `v0.16.2`
  - Update `ere-compiler-openvm` to [`1d673fa4063aed15e039a0fe8cf5915d96e8fb7bd9bd7d2587d1ccf2c21e7eb1`](https://github.com/eth-act/ere/pkgs/container/ere%2Fere-compiler-openvm/1155841214?tag=0.16.2)
  - Update `ere-server-openvm` to [`d56f5f59f1560bc2b58e84165accb8dc6586596ca1b9ff53b99862560f7b563c`](https://github.com/eth-act/ere/pkgs/container/ere%2Fere-server-openvm/1155842821?tag=0.16.2)
  - Update `ere-compiler-sp1` to [`9c4f7fd724e1537415fa03622f006e0ac2544676100fe90e7b2363a88c67170b`](https://github.com/eth-act/ere/pkgs/container/ere%2Fere-compiler-sp1/1155829013?tag=0.16.2)
  - Update `ere-server-sp1` to [`561ba9d13e0f4f198c57ad8c76b8320f691635275f6567bcb27b36d4e4159af4`](https://github.com/eth-act/ere/pkgs/container/ere%2Fere-server-sp1/1155829214?tag=0.16.2)
  - Update `ere-compiler-zisk` to [`0ba9ef646d4359094e6043573530314b6717fab8c3b8bd96a7aa6329d39d172a`](https://github.com/eth-act/ere/pkgs/container/ere%2Fere-compiler-zisk/1155857414?tag=0.16.2)
  - Update `ere-server-zisk` to [`4d00a96890a26dc54b523e537e9c1b25a26cf18d166bd3614fc97bbd09317091`](https://github.com/eth-act/ere/pkgs/container/ere%2Fere-server-zisk/1155875462?tag=0.16.2)
- Add `target-feature=+unaligned-scalar-mem` for `zisk` guest to enable unaligned access (~10% performance boost on mainnet blocks)
- Tested zkVM execution locally and the failure cases are identical to host execution (12 failure cases)