### PR TITLE
refactor: deduplicate payload declarations

### DIFF
--- a/crates/stateless-validator-common/src/guest/input/new_payload_request.rs
+++ b/crates/stateless-validator-common/src/guest/input/new_payload_request.rs
@@ -123,90 +123,48 @@ pub struct ExecutionRequestsGloas {
     pub builder_exits: BuilderExitRequests,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
-#[ssz(progressive_container)]
-pub struct ExecutionPayloadV1 {
-    pub parent_hash: Hash32,
-    pub fee_recipient: Address,
-    pub state_root: Hash32,
-    pub receipts_root: Hash32,
-    pub logs_bloom: Bloom,
-    pub prev_randao: Hash32,
-    pub block_number: u64,
-    pub gas_limit: u64,
-    pub gas_used: u64,
-    pub timestamp: u64,
-    pub extra_data: ExtraData,
-    pub base_fee_per_gas: Uint256Bytes,
-    pub block_hash: Hash32,
-    pub transactions: Transactions,
+// Keep payloads flat: field order defines their SSZ encoding and progressive roots.
+macro_rules! execution_payload {
+    ($name:ident { $($field:ident: $ty:ty),* $(,)? }) => {
+        #[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
+        #[ssz(progressive_container)]
+        pub struct $name {
+            pub parent_hash: Hash32,
+            pub fee_recipient: Address,
+            pub state_root: Hash32,
+            pub receipts_root: Hash32,
+            pub logs_bloom: Bloom,
+            pub prev_randao: Hash32,
+            pub block_number: u64,
+            pub gas_limit: u64,
+            pub gas_used: u64,
+            pub timestamp: u64,
+            pub extra_data: ExtraData,
+            pub base_fee_per_gas: Uint256Bytes,
+            pub block_hash: Hash32,
+            pub transactions: Transactions,
+            $(pub $field: $ty,)*
+        }
+    };
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
-#[ssz(progressive_container)]
-pub struct ExecutionPayloadV2 {
-    pub parent_hash: Hash32,
-    pub fee_recipient: Address,
-    pub state_root: Hash32,
-    pub receipts_root: Hash32,
-    pub logs_bloom: Bloom,
-    pub prev_randao: Hash32,
-    pub block_number: u64,
-    pub gas_limit: u64,
-    pub gas_used: u64,
-    pub timestamp: u64,
-    pub extra_data: ExtraData,
-    pub base_fee_per_gas: Uint256Bytes,
-    pub block_hash: Hash32,
-    pub transactions: Transactions,
-    pub withdrawals: Withdrawals,
-}
+execution_payload!(ExecutionPayloadV1 {});
 
-#[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
-#[ssz(progressive_container)]
-pub struct ExecutionPayloadV3 {
-    pub parent_hash: Hash32,
-    pub fee_recipient: Address,
-    pub state_root: Hash32,
-    pub receipts_root: Hash32,
-    pub logs_bloom: Bloom,
-    pub prev_randao: Hash32,
-    pub block_number: u64,
-    pub gas_limit: u64,
-    pub gas_used: u64,
-    pub timestamp: u64,
-    pub extra_data: ExtraData,
-    pub base_fee_per_gas: Uint256Bytes,
-    pub block_hash: Hash32,
-    pub transactions: Transactions,
-    pub withdrawals: Withdrawals,
-    pub blob_gas_used: u64,
-    pub excess_blob_gas: u64,
-}
+execution_payload!(ExecutionPayloadV2 { withdrawals: Withdrawals });
 
-#[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
-#[ssz(progressive_container)]
-pub struct ExecutionPayloadV4 {
-    pub parent_hash: Hash32,
-    pub fee_recipient: Address,
-    pub state_root: Hash32,
-    pub receipts_root: Hash32,
-    pub logs_bloom: Bloom,
-    pub prev_randao: Hash32,
-    pub block_number: u64,
-    pub gas_limit: u64,
-    pub gas_used: u64,
-    pub timestamp: u64,
-    pub extra_data: ExtraData,
-    pub base_fee_per_gas: Uint256Bytes,
-    pub block_hash: Hash32,
-    pub transactions: Transactions,
-    pub withdrawals: Withdrawals,
-    pub blob_gas_used: u64,
-    pub excess_blob_gas: u64,
-    pub block_access_list: BlockAccessList,
-    pub slot_number: u64,
-}
+execution_payload!(ExecutionPayloadV3 {
+    withdrawals: Withdrawals,
+    blob_gas_used: u64,
+    excess_blob_gas: u64,
+});
+
+execution_payload!(ExecutionPayloadV4 {
+    withdrawals: Withdrawals,
+    blob_gas_used: u64,
+    excess_blob_gas: u64,
+    block_access_list: BlockAccessList,
+    slot_number: u64,
+});
 
 #[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
 pub struct NewPayloadRequestBellatrix {


### PR DESCRIPTION
Consolidate the 14 shared fields and derives of `ExecutionPayloadV1` through `ExecutionPayloadV4` in a private macro, keeping each version's additional fields explicit. This removes 42 lines while preserving the flat public structs and their SSZ layout. The expanded crate is identical after excluding the macro definition; witness logic and existing tests are unchanged.

Implemented with Codex assistance and an Omp Oracle consultation.
