### PR TITLE
Update to tests-zkevm@v0.8.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target/
 /output
 
 # EF test fixtures (downloaded by scripts/setup_ef_tests.sh)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
+checksum = "0b836b372d3b742b7c083d2617d6e68563cd5dadbd8752c461a935a756551e69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
+checksum = "b1befb37485ea71e8599e32ffd76c98af7c3720a34741d30abd87f41c3148407"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
+checksum = "fdd59d7221d384c46771ffbf6f18f70aa7753326351277857016bed5127b888f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
+checksum = "ca3e76d47e8de277cb55e7e77fa38adde835162fc01cddbe1b258b5e0a86035b"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -178,8 +178,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.38.0"
-source = "git+https://github.com/alloy-rs/evm?rev=065a125cde3a5c69990323aecab97ce4ed048237#065a125cde3a5c69990323aecab97ce4ed048237"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6bd5f7e5ce9858bac99275e3f548c3b63bb3e5806da0142dc0b2f518d3ec4a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -197,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
+checksum = "0680a2f7d4bbc6f48c0cb43368fa544918a1fa291e772bdb47c834ade338f363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -237,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5722ea29a9a85ecdba2516c58f50d71e77cd25f8ce7e9f4ee8570ddeee6df1"
+checksum = "2a523ca087dda941e53f6ecde5bf5df78b9dbe760f3f77488e13dbf355de4a84"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -252,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e4d278913f00ab611f5367448a3a800fed173ab791c3cc67b7a1b0d7afd305"
+checksum = "f263c8d752b15e19b7c2d3cbad00338ec2d7cc923a46cd1ff98aea2fa333166b"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -278,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
+checksum = "8795eecf50374a0dd942caff57922c59333c9991ead9eccbbc1709f55d73c7c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -345,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0a6cce3f97e5d9c0048081b5d173e0e406c2056c52c012e578a1d451ff0cdc"
+checksum = "1176430031ba27abfb51b95516cf71e8ce3ff4172c72f3136627f0f89813a739"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -360,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f6d7c9462a3cf3bb046d0b870b86f1ce8c6892157491abebba62913e6f53cb"
+checksum = "2a97960aa11b9984a18580b8dfbfc3eacfce1befa0d588b03ccc0bc5563d01f8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -373,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e23b5864b3ed3479285ae9af1924266d60cac839dc559d50da868a0734c1d3"
+checksum = "0a43d7b6b86be4885c7a76f1dfcde9651af2d419ff571e8ee7257de47101203b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -390,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
+checksum = "756eb5803e70985be4066b636194ccb5f6629e5d141817c1f0c50cea8350bf5c"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -412,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
+checksum = "cc142e40df0c3eb5983b1637a68ab33471d8d22b8f402c9ed8260411a4e89d86"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -424,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e1f6fae3ade809daa4c32bee35a30a439bb307209d7b42f3995988b5cc74b8"
+checksum = "b4c84f88f8a29d2607f98993687ed55a5943ba06819bc2126bb078dca54be943"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -439,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621cc39c34b85875858ef149598f3d5f9797dff9a3247f3606fcc06f9b20acc8"
+checksum = "58c81472fb0b73cbb18106e323e33e3f249f56318a330a8e0f6aa6e913e3519a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -545,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
+checksum = "25484345e4d89c259235e200d4f895eba33e70f125f4e8bb37a7aa69a97bd656"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2025,6 +2026,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "elf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,25 +2079,25 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 
 [[package]]
 name = "ere-prover-core"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 dependencies = [
  "anyhow",
  "auto_impl",
  "bincode 2.0.1",
+ "elf",
  "ere-codec",
  "ere-verifier-core",
- "indexmap 2.14.0",
  "serde",
  "strum",
  "thiserror",
@@ -2098,8 +2105,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-api"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 dependencies = [
  "prost",
  "serde",
@@ -2108,10 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "ere-server-client"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 dependencies = [
- "bincode 2.0.1",
  "ere-prover-core",
  "ere-server-api",
  "thiserror",
@@ -2120,16 +2126,16 @@ dependencies = [
 
 [[package]]
 name = "ere-util-tokio"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "ere-verifier-core"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 dependencies = [
  "auto_impl",
  "ere-codec",
@@ -4532,8 +4538,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4562,8 +4568,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4582,8 +4588,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34b0b409ecf930ed3850e92bd9b4d4f8a8c397eef23e8ba5b1a1a02682a94bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4602,8 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcb49ab084e764e7d20f710e2c9daa439380d0fc33f8bfee8c372bfdbc1f437"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4612,8 +4620,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "eyre",
  "reth-network-peers",
@@ -4626,13 +4634,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-primitives",
- "alloy-rlp",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -4641,8 +4648,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4654,8 +4661,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -4664,12 +4671,12 @@ dependencies = [
  "metrics",
  "page_size",
  "parking_lot",
- "quanta",
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
  "reth-metrics",
  "reth-nippy-jar",
+ "reth-primitives-traits",
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",
@@ -4683,8 +4690,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4709,8 +4716,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -4739,8 +4746,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4754,8 +4761,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4781,8 +4788,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -4792,8 +4799,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4808,8 +4815,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4824,8 +4831,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -4837,8 +4844,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4851,8 +4858,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -4861,8 +4868,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -4885,8 +4892,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4905,8 +4912,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4918,8 +4925,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4937,8 +4944,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "serde",
  "serde_json",
@@ -4947,8 +4954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -4964,8 +4971,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "bindgen",
  "cc",
@@ -4973,8 +4980,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "libc",
  "metrics",
@@ -4983,8 +4990,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -4992,8 +4999,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5005,8 +5012,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eip2124",
  "reth-net-banlist",
@@ -5016,8 +5023,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -5026,6 +5033,7 @@ dependencies = [
  "memmap2",
  "reth-fs-util",
  "serde",
+ "smallvec",
  "thiserror",
  "tracing",
  "zstd",
@@ -5033,8 +5041,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -5045,8 +5053,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -5057,8 +5065,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5080,8 +5088,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -5090,8 +5098,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9060738a07ca1b0d8ede3ce21d8187c57cc22ee9e2991b29cbbc663280f843cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5122,8 +5131,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -5133,6 +5142,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "itertools 0.14.0",
+ "libc",
  "metrics",
  "notify",
  "parking_lot",
@@ -5171,8 +5181,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -5187,8 +5197,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5202,8 +5212,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -5216,8 +5226,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -5230,8 +5240,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -5256,8 +5266,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5273,8 +5283,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5293,13 +5303,14 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "revm",
  "tracing",
 ]
 
 [[package]]
 name = "reth-tasks"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -5319,8 +5330,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -5329,8 +5340,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "clap",
  "eyre",
@@ -5347,8 +5358,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "base64",
  "clap",
@@ -5365,8 +5376,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5391,8 +5402,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5414,12 +5425,13 @@ dependencies = [
  "revm",
  "serde",
  "serde_with",
+ "thiserror",
 ]
 
 [[package]]
 name = "reth-trie-db"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -5434,8 +5446,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -5444,8 +5456,6 @@ dependencies = [
  "reth-execution-errors",
  "reth-primitives-traits",
  "reth-trie-common",
- "serde",
- "serde_json",
  "slotmap",
  "smallvec",
  "strum",
@@ -5454,16 +5464,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f1ebb37e81a596ce16e81bec6a0c9accbdb914cf19b9190eff69ed00395900"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc210dfb3b45482a9f7c8806f737f7848fb7054b04235e6816480e515c1fe2d5"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -5480,8 +5492,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d38e16b72ec1c836ec8490562bfb21003165ea8bc496086bf345680a6e6c41"
 dependencies = [
  "bitvec",
  "phf",
@@ -5491,8 +5504,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16835bc2ead203219a18fcc84c2c71879ad6b890e8a71150cf7f10e4e355dc4"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -5507,8 +5521,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4109bdceaca5ee6e27bf41f6b156f2b15892dc5bb47d3530bc4d3b3060077"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -5522,8 +5537,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d764afa9a1c9278c05d40461b07319d21ccb39c1bdf0e9dde7e5ea7d9be53d"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -5537,8 +5553,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
 dependencies = [
  "auto_impl",
  "either",
@@ -5550,8 +5567,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8d988f896e22b19962658bc1afcd0989f727d48b2860a8bd7ceaecbf72ce34"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -5568,8 +5586,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2584990403728b2e13fb5522510b61e4bb217c6a4c8f4d063447a6ddd7dd7cc"
 dependencies = [
  "auto_impl",
  "either",
@@ -5585,8 +5604,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "932f7fe05a2cdeb08195dd7e88a09a4da7c3660cdc6e62720839c77ba77f65aa"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -5597,8 +5617,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4dc0279f2a44770faa8c93d008df684440cf573c91b8e0e39d0d581abf7b3d"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -5621,8 +5642,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f4ba1a5757fe4398262290422c371556fcebf236f762f7ed7ff2c56768a63c"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -5631,8 +5653,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,48 +50,48 @@ stateless-validator-reth = { path = "crates/stateless-validator-reth", default-f
 tries = { path = "crates/tries", default-features = false }
 
 # reth
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
-reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de" }
-reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", rev = "3d270d933daeeb90c5735d81ff7f80c00322d6de", default-features = false }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
+reth-primitives-traits = { version = "0.7.0", default-features = false }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5" }
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", rev = "db702b511a9dfe5a80ef76685dd93652ffe37cc5", default-features = false }
 
 # alloy
-alloy-consensus = { version = "2.4.1", default-features = false }
-alloy-eips = { version = "2.4.1", default-features = false }
-alloy-genesis = { version = "2.4.1", default-features = false }
+alloy-consensus = { version = "2.4.2", default-features = false }
+alloy-eips = { version = "2.4.2", default-features = false }
+alloy-genesis = { version = "2.4.2", default-features = false }
 alloy-primitives = { version = "1.6.1", default-features = false, features = ["map-foldhash", "map-indexmap"] }
 alloy-rlp = { version = "0.3.16", default-features = false }
-alloy-rpc-types-debug = { version = "2.4.1", default-features = false }
-alloy-rpc-types-engine = { version = "2.4.1", default-features = false }
+alloy-rpc-types-debug = { version = "2.4.2", default-features = false }
+alloy-rpc-types-engine = { version = "2.4.2", default-features = false }
 alloy-trie = { version = "0.9.4", default-features = false }
 
 # revm
-revm = { version = "42.0.1", default-features = false }
-revm-bytecode = { version = "42.0.0", default-features = false }
-revm-database-interface = { version = "42.0.0", default-features = false }
-revm-state = { version = "42.0.0", default-features = false }
+revm = { version = "43.0.1", default-features = false }
+revm-bytecode = { version = "43.0.0", default-features = false }
+revm-database-interface = { version = "43.0.0", default-features = false }
+revm-state = { version = "43.0.0", default-features = false }
 
 # zkVM standard
 zkvm-interface = { git = "https://github.com/eth-act/zkvm-standards", rev = "282cd356c3a0498416bb0619f9c8a347ce9933fb" }
 
 # Ere
-ere-platform-core = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa" }
-ere-server-client = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa" }
-ere-util-tokio = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa" }
+ere-platform-core = { git = "https://github.com/eth-act/ere", tag = "v0.17.0" }
+ere-server-client = { git = "https://github.com/eth-act/ere", tag = "v0.17.0" }
+ere-util-tokio = { git = "https://github.com/eth-act/ere", tag = "v0.17.0" }
 
 # ssz
 libssz = { version = "0.3.0", default-features = false, features = ["alloc"] }
@@ -131,23 +131,3 @@ tar = "0.4"
 tempfile = "3.20"
 thiserror = { version = "2.0", default-features = false }
 walkdir = "2.5"
-
-# Temporary until the revm release containing bluealloy/revm#3855 is published.
-[patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "065a125cde3a5c69990323aecab97ce4ed048237" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-revm = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ Or manually:
 EF_TEST_TRIE=default cargo test -p ef-tests --release --features "asm-keccak ef-tests"
 ```
 
+## Running stateless validator tests
+
+The Reth validator tests use the `tests-zkevm@v0.8.4` execution-spec fixtures.
+The first run downloads the archive and checks its SHA-256 checksum.
+Later runs reuse the versioned fixture cache.
+
+```bash
+cargo test -p stateless-validator-tests --test host_execution --locked
+```
+
+The suite requires every fixture to pass, including the EIP-8037 cross-frame state gas refund tests.
+
 ## Contributing
 
 Contributions are welcome! Join the conversation in the [Telegram group][tg-url].

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
+checksum = "0b836b372d3b742b7c083d2617d6e68563cd5dadbd8752c461a935a756551e69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
+checksum = "b1befb37485ea71e8599e32ffd76c98af7c3720a34741d30abd87f41c3148407"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
+checksum = "fdd59d7221d384c46771ffbf6f18f70aa7753326351277857016bed5127b888f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
+checksum = "ca3e76d47e8de277cb55e7e77fa38adde835162fc01cddbe1b258b5e0a86035b"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -156,8 +156,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.38.0"
-source = "git+https://github.com/alloy-rs/evm?rev=065a125cde3a5c69990323aecab97ce4ed048237#065a125cde3a5c69990323aecab97ce4ed048237"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6bd5f7e5ce9858bac99275e3f548c3b63bb3e5806da0142dc0b2f518d3ec4a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -173,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
+checksum = "0680a2f7d4bbc6f48c0cb43368fa544918a1fa291e772bdb47c834ade338f363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -200,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
+checksum = "8795eecf50374a0dd942caff57922c59333c9991ead9eccbbc1709f55d73c7c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -258,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f6d7c9462a3cf3bb046d0b870b86f1ce8c6892157491abebba62913e6f53cb"
+checksum = "2a97960aa11b9984a18580b8dfbfc3eacfce1befa0d588b03ccc0bc5563d01f8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -271,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e23b5864b3ed3479285ae9af1924266d60cac839dc559d50da868a0734c1d3"
+checksum = "0a43d7b6b86be4885c7a76f1dfcde9651af2d419ff571e8ee7257de47101203b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -285,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
+checksum = "756eb5803e70985be4066b636194ccb5f6629e5d141817c1f0c50cea8350bf5c"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -297,7 +298,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -305,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
+checksum = "cc142e40df0c3eb5983b1637a68ab33471d8d22b8f402c9ed8260411a4e89d86"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -390,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
+checksum = "25484345e4d89c259235e200d4f895eba33e70f125f4e8bb37a7aa69a97bd656"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1206,13 +1207,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2713,8 +2714,8 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2733,8 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34b0b409ecf930ed3850e92bd9b4d4f8a8c397eef23e8ba5b1a1a02682a94bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2750,8 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcb49ab084e764e7d20f710e2c9daa439380d0fc33f8bfee8c372bfdbc1f437"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2760,13 +2763,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-primitives",
- "alloy-rlp",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -2775,8 +2777,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2788,8 +2790,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2798,8 +2800,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2814,8 +2816,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -2826,8 +2828,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2840,8 +2842,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2863,8 +2865,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2883,8 +2885,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -2896,8 +2898,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2912,8 +2914,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2924,8 +2926,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -2934,8 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9060738a07ca1b0d8ede3ce21d8187c57cc22ee9e2991b29cbbc663280f843cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2959,8 +2962,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2971,8 +2974,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -2980,8 +2983,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2993,8 +2996,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3016,8 +3019,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3033,8 +3036,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3045,20 +3048,23 @@ dependencies = [
  "nybbles",
  "reth-primitives-traits",
  "revm",
+ "thiserror",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f1ebb37e81a596ce16e81bec6a0c9accbdb914cf19b9190eff69ed00395900"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc210dfb3b45482a9f7c8806f737f7848fb7054b04235e6816480e515c1fe2d5"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3075,8 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d38e16b72ec1c836ec8490562bfb21003165ea8bc496086bf345680a6e6c41"
 dependencies = [
  "bitvec",
  "phf",
@@ -3086,8 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16835bc2ead203219a18fcc84c2c71879ad6b890e8a71150cf7f10e4e355dc4"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3101,8 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4109bdceaca5ee6e27bf41f6b156f2b15892dc5bb47d3530bc4d3b3060077"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3115,8 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d764afa9a1c9278c05d40461b07319d21ccb39c1bdf0e9dde7e5ea7d9be53d"
 dependencies = [
  "derive_more",
  "either",
@@ -3128,8 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
 dependencies = [
  "auto_impl",
  "either",
@@ -3140,8 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8d988f896e22b19962658bc1afcd0989f727d48b2860a8bd7ceaecbf72ce34"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3157,8 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2584990403728b2e13fb5522510b61e4bb217c6a4c8f4d063447a6ddd7dd7cc"
 dependencies = [
  "auto_impl",
  "either",
@@ -3172,8 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "932f7fe05a2cdeb08195dd7e88a09a4da7c3660cdc6e62720839c77ba77f65aa"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3183,8 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4dc0279f2a44770faa8c93d008df684440cf573c91b8e0e39d0d581abf7b3d"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3204,8 +3219,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f4ba1a5757fe4398262290422c371556fcebf236f762f7ed7ff2c56768a63c"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3214,8 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.1",

--- a/bin/stateless-validator-reth/openvm/Cargo.toml
+++ b/bin/stateless-validator-reth/openvm/Cargo.toml
@@ -13,7 +13,7 @@ alloy-primitives = { version = "1.6.1", default-features = false, features = [
 ] }
 
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.17.0", features = [
     "std",
     "zkvm-accelerator",
 ] }
@@ -22,26 +22,6 @@ ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "8961a4e7a
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", features = [
     "zkvm-interface",
 ] }
-
-# Temporary until the revm release containing bluealloy/revm#3855 is published.
-[patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "065a125cde3a5c69990323aecab97ce4ed048237" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-revm = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
 
 [profile.release]
 codegen-units = 1

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
+checksum = "0b836b372d3b742b7c083d2617d6e68563cd5dadbd8752c461a935a756551e69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
+checksum = "b1befb37485ea71e8599e32ffd76c98af7c3720a34741d30abd87f41c3148407"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
+checksum = "fdd59d7221d384c46771ffbf6f18f70aa7753326351277857016bed5127b888f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
+checksum = "ca3e76d47e8de277cb55e7e77fa38adde835162fc01cddbe1b258b5e0a86035b"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -167,8 +167,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.38.0"
-source = "git+https://github.com/alloy-rs/evm?rev=065a125cde3a5c69990323aecab97ce4ed048237#065a125cde3a5c69990323aecab97ce4ed048237"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6bd5f7e5ce9858bac99275e3f548c3b63bb3e5806da0142dc0b2f518d3ec4a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -184,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
+checksum = "0680a2f7d4bbc6f48c0cb43368fa544918a1fa291e772bdb47c834ade338f363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -211,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
+checksum = "8795eecf50374a0dd942caff57922c59333c9991ead9eccbbc1709f55d73c7c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -269,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f6d7c9462a3cf3bb046d0b870b86f1ce8c6892157491abebba62913e6f53cb"
+checksum = "2a97960aa11b9984a18580b8dfbfc3eacfce1befa0d588b03ccc0bc5563d01f8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -282,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e23b5864b3ed3479285ae9af1924266d60cac839dc559d50da868a0734c1d3"
+checksum = "0a43d7b6b86be4885c7a76f1dfcde9651af2d419ff571e8ee7257de47101203b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -296,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
+checksum = "756eb5803e70985be4066b636194ccb5f6629e5d141817c1f0c50cea8350bf5c"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -308,7 +309,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -316,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
+checksum = "cc142e40df0c3eb5983b1637a68ab33471d8d22b8f402c9ed8260411a4e89d86"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -401,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
+checksum = "25484345e4d89c259235e200d4f895eba33e70f125f4e8bb37a7aa69a97bd656"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1270,13 +1271,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 dependencies = [
  "ere-platform-core",
  "libzkevm",
@@ -2717,8 +2718,8 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2737,8 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34b0b409ecf930ed3850e92bd9b4d4f8a8c397eef23e8ba5b1a1a02682a94bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2754,8 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcb49ab084e764e7d20f710e2c9daa439380d0fc33f8bfee8c372bfdbc1f437"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2764,13 +2767,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-primitives",
- "alloy-rlp",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -2779,8 +2781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2792,8 +2794,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2802,8 +2804,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2818,8 +2820,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -2830,8 +2832,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2844,8 +2846,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2867,8 +2869,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2887,8 +2889,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -2900,8 +2902,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2916,8 +2918,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2928,8 +2930,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -2938,8 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9060738a07ca1b0d8ede3ce21d8187c57cc22ee9e2991b29cbbc663280f843cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2963,8 +2966,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2975,8 +2978,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -2984,8 +2987,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2997,8 +3000,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3020,8 +3023,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3037,8 +3040,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3049,20 +3052,23 @@ dependencies = [
  "nybbles",
  "reth-primitives-traits",
  "revm",
+ "thiserror",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f1ebb37e81a596ce16e81bec6a0c9accbdb914cf19b9190eff69ed00395900"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc210dfb3b45482a9f7c8806f737f7848fb7054b04235e6816480e515c1fe2d5"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3079,8 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d38e16b72ec1c836ec8490562bfb21003165ea8bc496086bf345680a6e6c41"
 dependencies = [
  "bitvec",
  "phf",
@@ -3090,8 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16835bc2ead203219a18fcc84c2c71879ad6b890e8a71150cf7f10e4e355dc4"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3105,8 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4109bdceaca5ee6e27bf41f6b156f2b15892dc5bb47d3530bc4d3b3060077"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3119,8 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d764afa9a1c9278c05d40461b07319d21ccb39c1bdf0e9dde7e5ea7d9be53d"
 dependencies = [
  "derive_more",
  "either",
@@ -3132,8 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
 dependencies = [
  "auto_impl",
  "either",
@@ -3144,8 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8d988f896e22b19962658bc1afcd0989f727d48b2860a8bd7ceaecbf72ce34"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3161,8 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2584990403728b2e13fb5522510b61e4bb217c6a4c8f4d063447a6ddd7dd7cc"
 dependencies = [
  "auto_impl",
  "either",
@@ -3176,8 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "932f7fe05a2cdeb08195dd7e88a09a4da7c3660cdc6e62720839c77ba77f65aa"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3187,8 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4dc0279f2a44770faa8c93d008df684440cf573c91b8e0e39d0d581abf7b3d"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3208,8 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f4ba1a5757fe4398262290422c371556fcebf236f762f7ed7ff2c56768a63c"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3218,8 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.1",

--- a/bin/stateless-validator-reth/sp1/Cargo.toml
+++ b/bin/stateless-validator-reth/sp1/Cargo.toml
@@ -13,7 +13,7 @@ alloy-primitives = { version = "1.6.1", default-features = false, features = [
 ] }
 
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.17.0" }
 
 # local
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", default-features = false, features = [
@@ -23,25 +23,6 @@ stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", 
 [patch.crates-io]
 # FIXME: Remove the patch once https://github.com/succinctlabs/sp1/pull/2865 is merged and released.
 sp1-lib = { git = "https://github.com/han0110/sp1", rev = "7929b001303feb6803ce1214557d5ab1f17eee84" }
-
-# Temporary until the revm release containing bluealloy/revm#3855 is published.
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "065a125cde3a5c69990323aecab97ce4ed048237" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-revm = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
 
 [patch."https://github.com/succinctlabs/sp1.git"]
 sp1-lib = { git = "https://github.com/han0110/sp1", rev = "7929b001303feb6803ce1214557d5ab1f17eee84" }

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
+checksum = "0b836b372d3b742b7c083d2617d6e68563cd5dadbd8752c461a935a756551e69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
+checksum = "b1befb37485ea71e8599e32ffd76c98af7c3720a34741d30abd87f41c3148407"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
+checksum = "fdd59d7221d384c46771ffbf6f18f70aa7753326351277857016bed5127b888f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
+checksum = "ca3e76d47e8de277cb55e7e77fa38adde835162fc01cddbe1b258b5e0a86035b"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -156,8 +156,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.38.0"
-source = "git+https://github.com/alloy-rs/evm?rev=065a125cde3a5c69990323aecab97ce4ed048237#065a125cde3a5c69990323aecab97ce4ed048237"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6bd5f7e5ce9858bac99275e3f548c3b63bb3e5806da0142dc0b2f518d3ec4a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -173,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
+checksum = "0680a2f7d4bbc6f48c0cb43368fa544918a1fa291e772bdb47c834ade338f363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -200,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
+checksum = "8795eecf50374a0dd942caff57922c59333c9991ead9eccbbc1709f55d73c7c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -258,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f6d7c9462a3cf3bb046d0b870b86f1ce8c6892157491abebba62913e6f53cb"
+checksum = "2a97960aa11b9984a18580b8dfbfc3eacfce1befa0d588b03ccc0bc5563d01f8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -271,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e23b5864b3ed3479285ae9af1924266d60cac839dc559d50da868a0734c1d3"
+checksum = "0a43d7b6b86be4885c7a76f1dfcde9651af2d419ff571e8ee7257de47101203b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -285,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
+checksum = "756eb5803e70985be4066b636194ccb5f6629e5d141817c1f0c50cea8350bf5c"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -297,7 +298,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -305,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
+checksum = "cc142e40df0c3eb5983b1637a68ab33471d8d22b8f402c9ed8260411a4e89d86"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -390,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
+checksum = "25484345e4d89c259235e200d4f895eba33e70f125f4e8bb37a7aa69a97bd656"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1329,13 +1330,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.16.2"
-source = "git+https://github.com/eth-act/ere?rev=8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa#8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa"
+version = "0.17.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.17.0#5023513851c69ab9c4871e3899608e450e6960b6"
 dependencies = [
  "ere-platform-core",
  "ziskos",
@@ -2468,8 +2469,8 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2488,8 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34b0b409ecf930ed3850e92bd9b4d4f8a8c397eef23e8ba5b1a1a02682a94bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2505,8 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcb49ab084e764e7d20f710e2c9daa439380d0fc33f8bfee8c372bfdbc1f437"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2515,13 +2518,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-primitives",
- "alloy-rlp",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -2530,8 +2532,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2543,8 +2545,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2553,8 +2555,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2569,8 +2571,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -2581,8 +2583,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2595,8 +2597,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2618,8 +2620,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2638,8 +2640,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -2651,8 +2653,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2667,8 +2669,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2679,8 +2681,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -2689,8 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9060738a07ca1b0d8ede3ce21d8187c57cc22ee9e2991b29cbbc663280f843cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2714,8 +2717,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2726,8 +2729,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -2735,8 +2738,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2748,8 +2751,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2771,8 +2774,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2788,8 +2791,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3d270d933daeeb90c5735d81ff7f80c00322d6de#3d270d933daeeb90c5735d81ff7f80c00322d6de"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=db702b511a9dfe5a80ef76685dd93652ffe37cc5#db702b511a9dfe5a80ef76685dd93652ffe37cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -2800,20 +2803,23 @@ dependencies = [
  "nybbles",
  "reth-primitives-traits",
  "revm",
+ "thiserror",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.6.0"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b#1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f1ebb37e81a596ce16e81bec6a0c9accbdb914cf19b9190eff69ed00395900"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc210dfb3b45482a9f7c8806f737f7848fb7054b04235e6816480e515c1fe2d5"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -2830,8 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d38e16b72ec1c836ec8490562bfb21003165ea8bc496086bf345680a6e6c41"
 dependencies = [
  "bitvec",
  "phf",
@@ -2841,8 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16835bc2ead203219a18fcc84c2c71879ad6b890e8a71150cf7f10e4e355dc4"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -2856,8 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4109bdceaca5ee6e27bf41f6b156f2b15892dc5bb47d3530bc4d3b3060077"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -2870,8 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d764afa9a1c9278c05d40461b07319d21ccb39c1bdf0e9dde7e5ea7d9be53d"
 dependencies = [
  "derive_more",
  "either",
@@ -2883,8 +2893,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
 dependencies = [
  "auto_impl",
  "either",
@@ -2895,8 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8d988f896e22b19962658bc1afcd0989f727d48b2860a8bd7ceaecbf72ce34"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -2912,8 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2584990403728b2e13fb5522510b61e4bb217c6a4c8f4d063447a6ddd7dd7cc"
 dependencies = [
  "auto_impl",
  "either",
@@ -2927,8 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "932f7fe05a2cdeb08195dd7e88a09a4da7c3660cdc6e62720839c77ba77f65aa"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -2938,8 +2952,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4dc0279f2a44770faa8c93d008df684440cf573c91b8e0e39d0d581abf7b3d"
 dependencies = [
  "ark-bls12-381 0.6.0",
  "ark-bn254 0.6.0",
@@ -2959,8 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f4ba1a5757fe4398262290422c371556fcebf236f762f7ed7ff2c56768a63c"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -2969,8 +2985,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=45f05bd88fd09e32ea43cf5e94190759ea6ace7c#45f05bd88fd09e32ea43cf5e94190759ea6ace7c"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.1",

--- a/bin/stateless-validator-reth/zisk/Cargo.toml
+++ b/bin/stateless-validator-reth/zisk/Cargo.toml
@@ -16,7 +16,7 @@ alloy-primitives = { version = "1.6.1", default-features = false, features = [
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5c9ca2dc6a2fc848452f23a186b1aa", default-features = false, features = [
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.17.0", default-features = false, features = [
     "inputcpy",
 ] }
 
@@ -24,26 +24,6 @@ ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "8961a4e7ac5
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", default-features = false, features = [
     "zkvm-interface",
 ] }
-
-# Temporary until the revm release containing bluealloy/revm#3855 is published.
-[patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "065a125cde3a5c69990323aecab97ce4ed048237" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1207f7ff0534f6a7fe4d9661ea20d070b67d9c8b" }
-revm = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "45f05bd88fd09e32ea43cf5e94190759ea6ace7c" }
 
 [profile.release]
 codegen-units = 1

--- a/crates/stateless-validator-common/src/guest/input.rs
+++ b/crates/stateless-validator-common/src/guest/input.rs
@@ -4,8 +4,8 @@
 //! format is a 2-byte big-endian schema identifier followed by the SSZ-encoded `StatelessInput`
 //! container.
 //!
-//! [`stateless.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/stateless.py
-//! [`stateless_ssz.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/stateless_ssz.py
+//! [`stateless.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/stateless.py
+//! [`stateless_ssz.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/stateless_ssz.py
 
 #![allow(missing_docs)]
 
@@ -114,7 +114,7 @@ impl StatelessInput {
     /// Serializes to schema-prefixed SSZ bytes, mirroring `serialize_stateless_input` in
     /// [`stateless_host.py`]. The fork is encoded into the schema identifier prefix.
     ///
-    /// [`stateless_host.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/stateless_host.py
+    /// [`stateless_host.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/stateless_host.py
     pub fn to_schema_prefixed_ssz(&self, fork: ProtocolFork) -> Vec<u8> {
         let mut out = Vec::with_capacity(STATELESS_INPUT_SCHEMA_ID_SIZE + self.encoded_len());
         out.extend_from_slice(&fork.schema_id().to_be_bytes());
@@ -126,7 +126,7 @@ impl StatelessInput {
     /// [`stateless_guest.py`]. Returns the fork carried by the schema identifier alongside the
     /// decoded input, and rejects a payload request whose shape does not match that fork.
     ///
-    /// [`stateless_guest.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/stateless_guest.py
+    /// [`stateless_guest.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/stateless_guest.py
     pub fn from_schema_prefixed_ssz(bytes: &[u8]) -> Result<(ProtocolFork, Self), Error> {
         use ProtocolFork::*;
         let (schema_id, body) = bytes

--- a/crates/stateless-validator-common/src/guest/input/new_payload_request.rs
+++ b/crates/stateless-validator-common/src/guest/input/new_payload_request.rs
@@ -5,9 +5,9 @@
 //! execution-apis, because a multi-fork crate needs distinct names while each execution-specs
 //! fork module defines a single `ExecutionPayload` shape.
 //!
-//! [`types.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/execution_engine/types.py
-//! [`requests.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/execution_engine/requests.py
-//! [`blocks.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/blocks.py
+//! [`types.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/execution_engine/types.py
+//! [`requests.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/execution_engine/requests.py
+//! [`blocks.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/blocks.py
 
 #![allow(missing_docs)]
 

--- a/crates/stateless-validator-common/src/guest/output.rs
+++ b/crates/stateless-validator-common/src/guest/output.rs
@@ -3,8 +3,8 @@
 //! The types mirror `StatelessValidationResult` in [`stateless.py`] and its SSZ schema in
 //! [`stateless_ssz.py`]. The serialized form is the plain SSZ encoding without a schema prefix.
 //!
-//! [`stateless.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/stateless.py
-//! [`stateless_ssz.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/stateless_ssz.py
+//! [`stateless.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/stateless.py
+//! [`stateless_ssz.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/stateless_ssz.py
 
 use alloc::vec::Vec;
 

--- a/crates/stateless-validator-reth/src/guest/convert.rs
+++ b/crates/stateless-validator-reth/src/guest/convert.rs
@@ -316,7 +316,7 @@ fn compute_requests_hash(
 /// mirroring `encode_execution_requests` in [`requests.py`]. A list holding no items has no wire
 /// form and contributes nothing to the commitment.
 ///
-/// [`requests.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.2/src/ethereum/forks/amsterdam/execution_engine/requests.py
+/// [`requests.py`]: https://github.com/ethereum/execution-specs/blob/tests-zkevm@v0.8.4/src/ethereum/forks/amsterdam/execution_engine/requests.py
 fn encode_execution_requests<T: SszEncode>(request_type: u8, requests: &[T]) -> Option<Vec<u8>> {
     if requests.is_empty() {
         return None;

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -25,7 +25,7 @@ use reth_evm::{
     execute::{BlockExecutionOutput, Executor},
 };
 use reth_primitives_traits::{RecoveredBlock, SealedHeader};
-use reth_trie_common::{HashedStorage, KeccakKeyHasher, KeyHasher};
+use reth_trie_common::{HashedPostState, KeccakKeyHasher};
 use tries::{StatelessTrie, StatelessTrieError};
 
 #[cfg(feature = "reth-trie")]
@@ -314,24 +314,17 @@ where
     )
     .map_err(StatelessValidationError::ConsensusValidationFailed)?;
 
-    let hashed_state = output
-        .state
-        .state()
-        .iter()
-        .map(|(address, account)| {
-            let hashed_address = KeccakKeyHasher::hash_key(address);
-            let hashed_account = account.info.as_ref().map(Into::into);
-            let mut hashed_storage = HashedStorage::from_iter(
-                account
-                    .storage
-                    .iter()
-                    .map(|(slot, value)| (keccak256(B256::from(*slot)), value.present_value)),
-            );
-            hashed_storage.wiped = account.was_destroyed();
-
-            (hashed_address, hashed_account, (!hashed_storage.is_empty()).then_some(hashed_storage))
-        })
-        .collect();
+    let mut hashed_state =
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(output.state.state());
+    // Reth no longer carries storage-wipe markers in HashedPostState. Reset storage directly
+    // so accounts destroyed and recreated in the block cannot retain untouched pre-state slots.
+    for (address, account) in output.state.state() {
+        if account.was_destroyed() {
+            let hashed_address = keccak256(address);
+            trie.clear_storage(hashed_address);
+            hashed_state.storages.entry(hashed_address).or_default();
+        }
+    }
     let state_root = trie.calculate_state_root(hashed_state)?;
     if state_root != current_block.state_root {
         return Err(StatelessValidationError::PostStateRootMismatch {

--- a/crates/tries/src/default.rs
+++ b/crates/tries/src/default.rs
@@ -117,6 +117,10 @@ impl StatelessTrie for StatelessSparseTrie {
         self.storage(address, slot)
     }
 
+    fn clear_storage(&mut self, hashed_address: B256) {
+        self.inner.insert_storage_trie(hashed_address, RevealableSparseTrie::revealed_empty());
+    }
+
     fn calculate_state_root(&mut self, state: HashedPostState) -> Result<B256, StatelessTrieError> {
         self.calculate_state_root(state)
     }
@@ -297,10 +301,6 @@ fn calculate_state_root(
         // Take the existing storage trie (or create an empty, "revealed" one)
         let mut storage_trie =
             trie.take_storage_trie(&address).unwrap_or_else(RevealableSparseTrie::revealed_empty);
-
-        if storage.wiped {
-            storage_trie.wipe()?;
-        }
 
         let mut updates = storage
             .storage

--- a/crates/tries/src/lib.rs
+++ b/crates/tries/src/lib.rs
@@ -41,6 +41,75 @@ pub trait StatelessTrie: core::fmt::Debug {
     /// Returns the storage slot value that corresponds to the `(address, slot)` tuple.
     fn storage(&self, address: Address, slot: U256) -> Result<U256, WitnessDbError>;
 
+    /// Clears an account's storage before applying its post-state changes.
+    ///
+    /// The address is hashed, as in [`HashedPostState`]. Clearing must also discard blinded slots.
+    fn clear_storage(&mut self, hashed_address: B256);
+
     /// Computes the new state root from the [`HashedPostState`].
     fn calculate_state_root(&mut self, state: HashedPostState) -> Result<B256, StatelessTrieError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{U256, keccak256};
+    use reth_trie_common::HashedStorage;
+    use zeth_mpt::Trie;
+
+    fn storage_reset_discards_unrevealed_slots<T: StatelessTrie>(new_value: U256) {
+        let address = Address::with_last_byte(1);
+        let hashed_address = keccak256(address);
+        let old_slot = U256::from(1);
+        let new_slot = U256::from(2);
+
+        let mut storage = Trie::default();
+        storage.insert(keccak256(B256::from(old_slot)), alloy_rlp::encode(U256::from(42)));
+        let mut account = TrieAccount { storage_root: storage.hash_slow(), ..Default::default() };
+        let mut state = Trie::default();
+        state.insert(hashed_address, alloy_rlp::encode(account));
+
+        // A storage reset must not require witnesses for the old slots.
+        let witness = ExecutionWitness { state: state.rlp_nodes(), ..Default::default() };
+        let (mut trie, _) = T::new(witness, state.hash_slow()).unwrap();
+        trie.clear_storage(hashed_address);
+
+        let mut post_state = HashedPostState::default();
+        post_state.accounts.insert(hashed_address, Some(Default::default()));
+        post_state.storages.insert(
+            hashed_address,
+            if new_value.is_zero() {
+                HashedStorage::default()
+            } else {
+                HashedStorage::from_iter([(keccak256(B256::from(new_slot)), new_value)])
+            },
+        );
+
+        storage.clear();
+        if !new_value.is_zero() {
+            storage.insert(keccak256(B256::from(new_slot)), alloy_rlp::encode(new_value));
+        }
+        account.storage_root = storage.hash_slow();
+        state.insert(hashed_address, alloy_rlp::encode(account));
+        assert_eq!(trie.calculate_state_root(post_state).unwrap(), state.hash_slow());
+        assert_eq!(trie.storage(address, old_slot).unwrap(), U256::ZERO);
+        assert_eq!(trie.storage(address, new_slot).unwrap(), new_value);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn reth_storage_reset_discards_unrevealed_slots() {
+        for new_value in [U256::ZERO, U256::from(7)] {
+            storage_reset_discards_unrevealed_slots::<crate::default::StatelessSparseTrie>(
+                new_value,
+            );
+        }
+    }
+
+    #[test]
+    fn zeth_storage_reset_discards_unrevealed_slots() {
+        for new_value in [U256::ZERO, U256::from(7)] {
+            storage_reset_discards_unrevealed_slots::<crate::zeth::SparseState>(new_value);
+        }
+    }
 }

--- a/crates/tries/src/zeth.rs
+++ b/crates/tries/src/zeth.rs
@@ -161,6 +161,10 @@ impl StatelessTrie for SparseState {
         Ok(storage_trie.get(keccak256(B256::from(slot)))?.unwrap_or(U256::ZERO))
     }
 
+    fn clear_storage(&mut self, hashed_address: B256) {
+        self.clear_storage(hashed_address);
+    }
+
     /// Computes the new state root from the HashedPostState.
     fn calculate_state_root(&mut self, state: HashedPostState) -> Result<B256, StatelessTrieError> {
         let mut removed_accounts = Vec::new();
@@ -179,12 +183,9 @@ impl StatelessTrie for SparseState {
                     .map_err(|_| StatelessTrieError::StatelessStateRootCalculationFailed)?
                     .map_or(EMPTY_ROOT_HASH, |account| account.storage_root),
                 Some(storage) => {
-                    let storage_trie = if storage.wiped {
-                        self.clear_storage(hashed_address)
-                    } else {
-                        self.storage_trie_mut(hashed_address)
-                            .map_err(|_| StatelessTrieError::StatelessStateRootCalculationFailed)?
-                    };
+                    let storage_trie = self
+                        .storage_trie_mut(hashed_address)
+                        .map_err(|_| StatelessTrieError::StatelessStateRootCalculationFailed)?;
 
                     // apply all state modifications
                     for (hashed_key, value) in &storage.storage {

--- a/scripts/guests/config.sh
+++ b/scripts/guests/config.sh
@@ -5,17 +5,17 @@ guest_config() {
         openvm)
             ZKVM_VERSION="v2.1.0-preview"
             COMPILER_IMAGE="ghcr.io/eth-act/ere/ere-compiler-openvm@sha256:1d673fa4063aed15e039a0fe8cf5915d96e8fb7bd9bd7d2587d1ccf2c21e7eb1"
-            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-openvm@sha256:d56f5f59f1560bc2b58e84165accb8dc6586596ca1b9ff53b99862560f7b563c"
+            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-openvm:0.17.0@sha256:31f59d76b60223fe2f59665ebc5e8a115d6e10f52f74e5bd291f630628e57f74"
             ;;
         sp1)
             ZKVM_VERSION="v6.4.0"
             COMPILER_IMAGE="ghcr.io/eth-act/ere/ere-compiler-sp1@sha256:9c4f7fd724e1537415fa03622f006e0ac2544676100fe90e7b2363a88c67170b"
-            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-sp1@sha256:561ba9d13e0f4f198c57ad8c76b8320f691635275f6567bcb27b36d4e4159af4"
+            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-sp1:0.17.0@sha256:cdf7597dda9d2b647e1b0a88374dd801897c14812828465f9258af1eed11b903"
             ;;
         zisk)
             ZKVM_VERSION="v1.1.0-alpha"
             COMPILER_IMAGE="ghcr.io/eth-act/ere/ere-compiler-zisk@sha256:0ba9ef646d4359094e6043573530314b6717fab8c3b8bd96a7aa6329d39d172a"
-            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-zisk@sha256:4d00a96890a26dc54b523e537e9c1b25a26cf18d166bd3614fc97bbd09317091"
+            SERVER_IMAGE="ghcr.io/eth-act/ere/ere-server-zisk:0.17.0@sha256:9dc91175d0790ef42d20e03630e9beb093f53abda5d4a39cdac3de4cca588012"
             ;;
         *)
             echo "unsupported zkVM: $1" >&2

--- a/testing/stateless-validator/src/fixture.rs
+++ b/testing/stateless-validator/src/fixture.rs
@@ -14,9 +14,9 @@ use sha2::{Digest, Sha256};
 use tar::Archive;
 use walkdir::{DirEntry, WalkDir};
 
-const EEST_FIXTURES_URL: &str = "https://github.com/ethereum/execution-specs/releases/download/tests-zkevm@v0.8.2/fixtures_zkevm.tar.gz";
+const EEST_FIXTURES_URL: &str = "https://github.com/ethereum/execution-specs/releases/download/tests-zkevm@v0.8.4/fixtures_zkevm.tar.gz";
 const EEST_FIXTURES_SHA256: &str =
-    "c58fbe493c1c37ab8371fd0ebb4ded668c08daf774f7f2fb798f6e7939810155";
+    "7a8c3537e85c8947354f6ffdebb0cab8dfb98b6b3031348808f85fb1fff58da3";
 
 /// A fixture normalized to canonical schema-prefixed SSZ input and output bytes.
 #[derive(Debug, Clone)]
@@ -29,7 +29,7 @@ pub struct StatelessValidatorFixture {
     pub stateless_output_bytes: Vec<u8>,
 }
 
-/// Returns all `tests-zkevm@v0.8.2` fixtures, downloading them on first use.
+/// Returns all `tests-zkevm@v0.8.4` fixtures, downloading them on first use.
 pub fn eest_fixtures() -> Vec<StatelessValidatorFixture> {
     load_fixtures_from_dir(ensure_eest_fixtures())
 }
@@ -79,7 +79,7 @@ fn ensure_eest_fixtures() -> PathBuf {
     let _guard = LOCK.lock().unwrap_or_else(|err| err.into_inner());
 
     let dir =
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures").join("eest-tests-zkevm-v0.8.2");
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures").join("eest-tests-zkevm-v0.8.4");
     if !dir.exists() {
         download_and_unpack(&dir);
     }

--- a/testing/stateless-validator/tests/host_execution.rs
+++ b/testing/stateless-validator/tests/host_execution.rs
@@ -5,30 +5,35 @@ use stateless_validator_tests::{
     fixture::eest_fixtures,
 };
 
-const EXPECTED_FAILURES: &[&str] = &[
-    "tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_from_state_test-opcode_CREATE-non-empty-balance-correct-initcode]#block0",
-    "tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_from_state_test-opcode_CREATE2-non-empty-balance-correct-initcode]#block0",
-    "tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_0-blockchain_test_from_state_test-non-empty-balance-correct-initcode]#block0",
-    "tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_0-blockchain_test_from_state_test-non-empty-balance-revert-initcode]#block0",
-    "tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_1-blockchain_test_from_state_test-non-empty-balance-correct-initcode]#block0",
-    "tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_1-blockchain_test_from_state_test-non-empty-balance-revert-initcode]#block0",
-    "tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_2-blockchain_test_from_state_test-non-empty-balance-correct-initcode]#block0",
-    "tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_2-blockchain_test_from_state_test-non-empty-balance-revert-initcode]#block0",
-    "tests/paris/eip7610_create_collision/test_revert_in_create.py::test_collision_with_create2_revert_in_initcode[fork_Amsterdam-blockchain_test_from_state_test]#block0",
-    "tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_from_state_test-empty-initcode]#block0",
-    "tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_from_state_test-initcode-with-deploy]#block0",
-    "tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_from_state_test-sstore-initcode]#block0",
-];
-
 #[test]
 fn executes_eest_glamsterdam_fixtures() {
-    let failures = run_host_execution(eest_fixtures());
-    let failure_names = failures.iter().map(|failure| failure.name.as_str()).collect::<Vec<_>>();
-    assert_eq!(
-        failure_names,
-        EXPECTED_FAILURES,
-        "unexpected upstream Reth failure set ({} failures):\n{}",
-        failures.len(),
+    let fixtures = eest_fixtures();
+    assert!(!fixtures.is_empty(), "no stateless validator fixtures loaded");
+
+    // Keep the EIP-8037 regressions that require bluealloy/revm#3893 in this suite.
+    for test in [
+        "test_cross_frame_refund_repays_spill_at_merge",
+        "test_cross_frame_refund_repays_spill_in_inner_frame",
+        "test_cross_frame_refund_with_reservoir_grant",
+        "test_child_clear_repays_own_spill_first",
+        "test_repaid_credit_funds_execution",
+        "test_cross_frame_refund_repays_spill_at_a_call",
+    ] {
+        let prefix = format!(
+            "tests/amsterdam/eip8037_state_creation_gas_cost_increase/\
+             test_state_gas_cross_frame_refund.py::{test}["
+        );
+        assert!(
+            fixtures.iter().any(|fixture| fixture.name.starts_with(&prefix)),
+            "missing EIP-8037 fixture: {test}",
+        );
+    }
+
+    println!("Executing {} stateless validator fixtures", fixtures.len());
+    let failures = run_host_execution(fixtures);
+    assert!(
+        failures.is_empty(),
+        "stateless validator fixture failures:\n{}",
         ExecutionFailures(&failures),
     );
 }

--- a/testing/stateless-validator/tests/host_execution.rs
+++ b/testing/stateless-validator/tests/host_execution.rs
@@ -10,25 +10,6 @@ fn executes_eest_glamsterdam_fixtures() {
     let fixtures = eest_fixtures();
     assert!(!fixtures.is_empty(), "no stateless validator fixtures loaded");
 
-    // Keep the EIP-8037 regressions that require bluealloy/revm#3893 in this suite.
-    for test in [
-        "test_cross_frame_refund_repays_spill_at_merge",
-        "test_cross_frame_refund_repays_spill_in_inner_frame",
-        "test_cross_frame_refund_with_reservoir_grant",
-        "test_child_clear_repays_own_spill_first",
-        "test_repaid_credit_funds_execution",
-        "test_cross_frame_refund_repays_spill_at_a_call",
-    ] {
-        let prefix = format!(
-            "tests/amsterdam/eip8037_state_creation_gas_cost_increase/\
-             test_state_gas_cross_frame_refund.py::{test}["
-        );
-        assert!(
-            fixtures.iter().any(|fixture| fixture.name.starts_with(&prefix)),
-            "missing EIP-8037 fixture: {test}",
-        );
-    }
-
     println!("Executing {} stateless validator fixtures", fixtures.len());
     let failures = run_host_execution(fixtures);
     assert!(


### PR DESCRIPTION
The [v0.8.4 fixtures](https://github.com/ethereum/execution-specs/releases/tag/tests-zkevm@v0.8.4) require the EIP-8037 refund fix from [REVM #3893](https://github.com/bluealloy/revm/pull/3893).
This PR updates Reth to include that fix and requires every stateless-validator fixture to pass.

The dependency changes are:

- Reth uses commit `db702b511a9dfe5a80ef76685dd93652ffe37cc5` and REVM `43.0.1`.
- The direct Alloy dependencies move from `2.4.1` to `2.4.2`.
- The manifests remove the temporary REVM, `alloy-evm`, and `reth-core` patches. The SP1 patches remain.
- Ere uses the `v0.17.0` tag. The guest scripts use matching server images with pinned digests.
- The root, OpenVM, SP1, and ZisK lockfiles include these updates.

It removes the 12 EIP-7610 exceptions because the newer fixture base excludes those cases.

Reth removed the storage-wipe marker from `HashedStorage`.
Both trie implementations now clear storage before they apply changes to destroyed accounts.
This also removes old storage slots absent from the witness.
Custom `StatelessTrie` implementations must provide `clear_storage`.

The validator entrypoints, SSZ schema, and guest input/output format remain unchanged.